### PR TITLE
Feature - Add GitHub repositories to user's saved list

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/constant/Constants.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/constant/Constants.kt
@@ -42,6 +42,12 @@ object DatabaseConstant {
      * about selected GitHub repository to view info.
      */
     const val ROOM_GITHUB_REPO_TABLE_NAME = "github_repo_table"
+
+    /**
+     * Constant string representing the name of the table in the database that stores
+     * a list of saved GitHub repositories for later reference.
+     */
+    const val ROOM_MY_SAVED_REPO_TABLE_NAME = "my_saved_repo_table"
 }
 
 /**

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/constant/Constants.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/constant/Constants.kt
@@ -60,6 +60,11 @@ object NavigationArgument {
      * The constant representing github repository info destination.
      */
     const val DESTINATION_GITHUB_REPO_INFO = "repo_info"
+
+    /**
+     * The constant representing github repository info destination.
+     */
+    const val DESTINATION_MY_SAVED_LIST = "saved_list"
 }
 
 /**

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/AppDatabase.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/AppDatabase.kt
@@ -9,7 +9,7 @@ import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
  * This abstract class represents the application's Room database. It defines the entities
  * that will be persisted and provides access to the corresponding DAO (Data Access Object).
  */
-@Database(entities = [LocalGitHubRepository::class, SavedGitHubRepository::class], version = 4)
+@Database(entities = [LocalGitHubRepository::class, SavedGitHubRepository::class], version = 6)
 abstract class AppDatabase : RoomDatabase() {
     /**
      * Returns the DAO (Data Access Object) used to interact with `LocalGitHubRepository` entities

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/AppDatabase.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/AppDatabase.kt
@@ -2,16 +2,14 @@ package jp.co.yumemi.android.code_check.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
-import jp.co.yumemi.android.code_check.constant.DatabaseConstant.ROOM_GITHUB_REPO_TABLE_NAME
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
 
 /**
  * This abstract class represents the application's Room database. It defines the entities
  * that will be persisted and provides access to the corresponding DAO (Data Access Object).
  */
-@Database(entities = [LocalGitHubRepository::class], version = 3)
+@Database(entities = [LocalGitHubRepository::class, SavedGitHubRepository::class], version = 4)
 abstract class AppDatabase : RoomDatabase() {
     /**
      * Returns the DAO (Data Access Object) used to interact with `LocalGitHubRepository` entities

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/GitHubRepositoryDao.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/GitHubRepositoryDao.kt
@@ -19,7 +19,7 @@ import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
 interface GitHubRepositoryDao {
     /**
      * Inserts a new `LocalGitHubRepository` object into the database to represent the
-     * GitHub repository selected by user to see more info from search results list or my saved list.
+     * GitHub repository selected by user to see more info from search results list or user's saved list.
      * If a record with the same [oneId] (primary key '1') already exists, it is replaced using the provided object.
      *
      * @param localGitHubRepository The `LocalGitHubRepository` object to be inserted.
@@ -43,7 +43,7 @@ interface GitHubRepositoryDao {
 
     /**
      * Inserts a new `SavedGitHubRepository` object into the database to represent the
-     * GitHub repository added to My saved list in the database.
+     * GitHub repository added to user's saved list in the database.
      *
      * @param savedGitHubRepository The `SavedGitHubRepository` object to be inserted.
      */
@@ -52,7 +52,7 @@ interface GitHubRepositoryDao {
 
     /**
      * Delete inserted `SavedGitHubRepository` object from the database. Then the deleted
-     * GitHub repository will not be shown in My saved list.
+     * GitHub repository will not be shown in user's saved list.
      *
      * @param savedGitHubRepository The `SavedGitHubRepository` object to be deleted.
      */
@@ -61,10 +61,10 @@ interface GitHubRepositoryDao {
 
     /**
      * Fetches a list of `SavedGitHubRepository` objects from the database
-     * representing the My saved list of GitHub repositories.
-     * This `SavedGitHubRepository` represents a GitHub repository added to My saved list.
+     * representing the user's saved list of GitHub repositories.
+     * This `SavedGitHubRepository` represents a GitHub repository added to user's saved list.
      *
-     * @return A a list of [SavedGitHubRepository] objects representing My saved list.
+     * @return A a list of [SavedGitHubRepository] objects representing user's saved list.
      */
     @Query("SELECT * FROM $ROOM_MY_SAVED_REPO_TABLE_NAME")
     fun getSavedGitHubRepositories(): List<SavedGitHubRepository>

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/GitHubRepositoryDao.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/database/GitHubRepositoryDao.kt
@@ -1,11 +1,14 @@
 package jp.co.yumemi.android.code_check.database
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import jp.co.yumemi.android.code_check.constant.DatabaseConstant.ROOM_GITHUB_REPO_TABLE_NAME
+import jp.co.yumemi.android.code_check.constant.DatabaseConstant.ROOM_MY_SAVED_REPO_TABLE_NAME
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
 
 /**
  * This interface defines the Data Access Object (DAO) for interacting with `LocalGitHubRepository`
@@ -16,7 +19,7 @@ import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
 interface GitHubRepositoryDao {
     /**
      * Inserts a new `LocalGitHubRepository` object into the database to represent the
-     * GitHub repository selected by user to see more info from search results list.
+     * GitHub repository selected by user to see more info from search results list or my saved list.
      * If a record with the same [oneId] (primary key '1') already exists, it is replaced using the provided object.
      *
      * @param localGitHubRepository The `LocalGitHubRepository` object to be inserted.
@@ -26,15 +29,43 @@ interface GitHubRepositoryDao {
 
     /**
      * Fetches a `LocalGitHubRepository` object from the database based on primary key [oneId].
-     * This `LocalGitHubRepository` is the github repository selected by user to see more info.
+     * This `LocalGitHubRepository` is the GitHub repository selected by user to see more info.
      *
-     * Since the table contains only one row to store the most recently selected github repository
+     * Since the table contains only one row to store the most recently selected GitHub repository
      * and that has fixed value (`1`) as the primary key [oneId], `1` has been passed to retrieve
      * the [LocalGitHubRepository].
      *
-     * @return A `LocalGitHubRepository` object representing the selected github repository by user
+     * @return A [LocalGitHubRepository] object representing the selected GitHub repository by user
      * to see more info, or null if no repository is found as selected GitHub repository.
      */
     @Query("SELECT * FROM $ROOM_GITHUB_REPO_TABLE_NAME WHERE oneId = 1")
     suspend fun getSelectedGitHubRepository(): LocalGitHubRepository?
+
+    /**
+     * Inserts a new `SavedGitHubRepository` object into the database to represent the
+     * GitHub repository added to My saved list in the database.
+     *
+     * @param savedGitHubRepository The `SavedGitHubRepository` object to be inserted.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSavedGitHubRepository(savedGitHubRepository: SavedGitHubRepository)
+
+    /**
+     * Delete inserted `SavedGitHubRepository` object from the database. Then the deleted
+     * GitHub repository will not be shown in My saved list.
+     *
+     * @param savedGitHubRepository The `SavedGitHubRepository` object to be deleted.
+     */
+    @Delete
+    suspend fun deleteSavedGitHubRepository(savedGitHubRepository: SavedGitHubRepository)
+
+    /**
+     * Fetches a list of `SavedGitHubRepository` objects from the database
+     * representing the My saved list of GitHub repositories.
+     * This `SavedGitHubRepository` represents a GitHub repository added to My saved list.
+     *
+     * @return A a list of [SavedGitHubRepository] objects representing My saved list.
+     */
+    @Query("SELECT * FROM $ROOM_MY_SAVED_REPO_TABLE_NAME")
+    fun getSavedGitHubRepositories(): List<SavedGitHubRepository>
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/GitHubRepositories.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/GitHubRepositories.kt
@@ -59,3 +59,25 @@ data class GitHubRepositoryOwner(
     @SerializedName("login") val login: String?,
     @SerializedName("avatar_url") val avatarUrl: String?
 ) : Parcelable
+
+/**
+ * Converts a [GitHubRepository] object to a corresponding [LocalGitHubRepository] object.
+ *
+ * @param isSaved Boolean indicating whether the repository is saved in the user's saved list in local database.
+ * @return A [LocalGitHubRepository] object with properties copied from the [GitHubRepository] object.
+ */
+fun GitHubRepository.toLocalGitHubRepository(isSaved: Boolean): LocalGitHubRepository {
+    return LocalGitHubRepository(
+        id = this.id,
+        forksCount = this.forksCount,
+        language = this.language,
+        name = this.name,
+        openIssuesCount = this.openIssuesCount,
+        stargazersCount = this.stargazersCount,
+        watchersCount = this.watchersCount,
+        htmlUrl = this.htmlUrl,
+        ownerLogin = this.owner?.login,
+        ownerAvatarUrl = this.owner?.avatarUrl,
+        isSaved = isSaved
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/LocalGitHubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/LocalGitHubRepository.kt
@@ -12,6 +12,7 @@ import jp.co.yumemi.android.code_check.constant.DatabaseConstant.ROOM_GITHUB_REP
  *  @param oneId [PrimaryKey]: This field serves as the primary key for the Room table.
  *      - Setting a fixed value (`1`) ensures a single row exists in the table. This approach is
  *        used to store GitHub repository selected by user to see more info from search results list.
+ *  @param id: Id of the GitHub Repository.
  *  @param forksCount: The number of forks associated with the GitHub repository (nullable).
  *  @param language: The programming language the GitHub repository is written in (nullable).
  *  @param name: The name of the GitHub repository (nullable).
@@ -21,7 +22,7 @@ import jp.co.yumemi.android.code_check.constant.DatabaseConstant.ROOM_GITHUB_REP
  *  @param htmlUrl: The URL to the GitHub repository's HTML page on GitHub (nullable).
  *  @param ownerLogin: The username of the GitHub repository owner (nullable).
  *  @param ownerAvatarUrl: The URL to the owner's avatar image (nullable).
- *  @param isFavorite: An additional field to track whether the user has favorite the GitHub repository). Defaults to `false`.
+ *  @param isSaved: To track whether the user has added the GitHub repository to user's saved list.
  *
  *  `@Entity(tableName = ROOM_GITHUB_REPO_TABLE_NAME)`: This annotation marks this class as a Room entity,
  *   mapping it to a table named "github_repo_table" within the Room database.
@@ -29,6 +30,7 @@ import jp.co.yumemi.android.code_check.constant.DatabaseConstant.ROOM_GITHUB_REP
 @Entity(tableName = ROOM_GITHUB_REPO_TABLE_NAME)
 data class LocalGitHubRepository(
     @PrimaryKey val oneId: Byte = 1,
+    val id: Long,
     val forksCount: Long?,
     val language: String?,
     val name: String?,
@@ -38,5 +40,27 @@ data class LocalGitHubRepository(
     val htmlUrl: String?,
     val ownerLogin: String?,
     val ownerAvatarUrl: String?,
-    val isFavorite: Boolean = false
+    val isSaved: Boolean
 )
+
+/**
+ * Converts a [GitHubRepository] object to a corresponding [SavedGitHubRepository] object.
+ *
+ * @param isSaved Boolean indicating whether the repository is saved in the user's saved list in local database.
+ * @return A [SavedGitHubRepository] object with properties copied from the [LocalGitHubRepository] object.
+ */
+fun LocalGitHubRepository.toSavedGitHubRepository(isSaved: Boolean): SavedGitHubRepository {
+    return SavedGitHubRepository(
+        id = this.id,
+        forksCount = this.forksCount,
+        language = this.language,
+        name = this.name,
+        openIssuesCount = this.openIssuesCount,
+        stargazersCount = this.stargazersCount,
+        watchersCount = this.watchersCount,
+        htmlUrl = this.htmlUrl,
+        ownerLogin = this.ownerLogin,
+        ownerAvatarUrl = this.ownerAvatarUrl,
+        isSaved = isSaved
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/SavedGitHubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/SavedGitHubRepository.kt
@@ -1,0 +1,40 @@
+package jp.co.yumemi.android.code_check.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import jp.co.yumemi.android.code_check.constant.DatabaseConstant
+
+/**
+ * Represents a local representation of a GitHub repository stored in the application's Room database.
+ * This class models information about a GitHub repository saved by user for later reference, including its core data retrieved from the
+ * GitHub API, and additional fields for user interaction tracking.
+ *
+ *  @param id [PrimaryKey]: Id of the GitHub Repository and the primary key for the Room table.
+ *  @param forksCount: The number of forks associated with the GitHub repository (nullable).
+ *  @param language: The programming language the GitHub repository is written in (nullable).
+ *  @param name: The name of the GitHub repository (nullable).
+ *  @param openIssuesCount: The number of open issues currently associated with the GitHub repository (nullable).
+ *  @param stargazersCount: The number of users who have starred the GitHub repository (nullable).
+ *  @param watchersCount: The number of users watching the GitHub repository (nullable).
+ *  @param htmlUrl: The URL to the GitHub repository's HTML page on GitHub (nullable).
+ *  @param ownerLogin: The username of the GitHub repository owner (nullable).
+ *  @param ownerAvatarUrl: The URL to the owner's avatar image (nullable).
+ *  @param isFavorite: An additional field to track whether the user has favorite the GitHub repository). Defaults to `false`.
+ *
+ *  `@Entity(tableName = ROOM_MY_SAVED_REPO_TABLE_NAME)`: This annotation marks this class as a Room entity,
+ *   mapping it to a table named "my_saved_repo_table" within the Room database.
+ */
+@Entity(tableName = DatabaseConstant.ROOM_MY_SAVED_REPO_TABLE_NAME)
+data class SavedGitHubRepository(
+    @PrimaryKey val id: Long,
+    val forksCount: Long?,
+    val language: String?,
+    val name: String?,
+    val openIssuesCount: Long?,
+    val stargazersCount: Long?,
+    val watchersCount: Long?,
+    val htmlUrl: String?,
+    val ownerLogin: String?,
+    val ownerAvatarUrl: String?,
+    val isFavorite: Boolean = false
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/SavedGitHubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/SavedGitHubRepository.kt
@@ -19,7 +19,7 @@ import jp.co.yumemi.android.code_check.constant.DatabaseConstant
  *  @param htmlUrl: The URL to the GitHub repository's HTML page on GitHub (nullable).
  *  @param ownerLogin: The username of the GitHub repository owner (nullable).
  *  @param ownerAvatarUrl: The URL to the owner's avatar image (nullable).
- *  @param isFavorite: An additional field to track whether the user has favorite the GitHub repository). Defaults to `false`.
+ *  @param isSaved: To track whether the user has added the GitHub repository to user's saved list.
  *
  *  `@Entity(tableName = ROOM_MY_SAVED_REPO_TABLE_NAME)`: This annotation marks this class as a Room entity,
  *   mapping it to a table named "my_saved_repo_table" within the Room database.
@@ -36,5 +36,27 @@ data class SavedGitHubRepository(
     val htmlUrl: String?,
     val ownerLogin: String?,
     val ownerAvatarUrl: String?,
-    val isFavorite: Boolean = false
+    val isSaved: Boolean
 )
+
+/**
+ * Converts a [SavedGitHubRepository] object to a corresponding [LocalGitHubRepository] object.
+ *
+ * @param isSaved Boolean indicating whether the repository is saved in the user's saved list in local database.
+ * @return A [LocalGitHubRepository] object with properties copied from the [SavedGitHubRepository] object.
+ */
+fun SavedGitHubRepository.toLocalGitHubRepository(): LocalGitHubRepository {
+    return LocalGitHubRepository(
+        id = this.id,
+        forksCount = this.forksCount,
+        language = this.language,
+        name = this.name,
+        openIssuesCount = this.openIssuesCount,
+        stargazersCount = this.stargazersCount,
+        watchersCount = this.watchersCount,
+        htmlUrl = this.htmlUrl,
+        ownerLogin = this.ownerLogin,
+        ownerAvatarUrl = this.ownerAvatarUrl,
+        isSaved = isSaved
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepository.kt
@@ -44,7 +44,7 @@ interface LocalGitHubDatabaseRepository {
     fun getSelectedGitHubRepositoryFromDatabase(): Flow<GitHubResponse<LocalGitHubRepository?>>
 
     /**
-     * Suspend function that saves selected Github repository in to My saved list.
+     * Suspend function that saves selected Github repository in to user's saved list.
      * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
      *
      * The emitted responses can be of the following types:
@@ -60,7 +60,7 @@ interface LocalGitHubDatabaseRepository {
     suspend fun addGitHubRepositoryToMySavedList(savedGitHubRepository: SavedGitHubRepository): Flow<GitHubResponse<Boolean>>
 
     /**
-     * Suspend function that deleted selected Github repository from My saved list in database.
+     * Suspend function that deleted selected Github repository from user's saved list in database.
      * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
      *
      * The emitted responses can be of the following types:
@@ -77,10 +77,10 @@ interface LocalGitHubDatabaseRepository {
 
     /**
      * Suspend function that fetches a list `SavedGitHubRepository` objects from the database.
-     * This `SavedGitHubRepository` represents a GitHub repository added to My saved list.
+     * This `SavedGitHubRepository` represents a GitHub repository added to user's saved list.
      *
      * @return A `Flow` of `GitHubResponse<List<SavedGitHubRepository>>` object. The emitted responses indicate the outcome:
-     *   - `Success` containing a list of `SavedGitHubRepository` objects representing the My saved list.
+     *   - `Success` containing a list of `SavedGitHubRepository` objects representing the user's saved list.
      *   - `Error` containing an error message if any exception occurred during the retrieval process.
      */
     suspend fun getMySavedList(): Flow<GitHubResponse<List<SavedGitHubRepository>>>

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepository.kt
@@ -2,6 +2,7 @@ package jp.co.yumemi.android.code_check.repository
 
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Singleton
 
@@ -35,11 +36,52 @@ interface LocalGitHubDatabaseRepository {
      * Since the table contains only one row to store the most recently selected github repository
      * that has fixed value (`1`) as the primary key [oneId], `1` has been passed to retrieve the [LocalGitHubRepository]
      *
-     * @param selectedGitHubRepositoryId The ID of the repository to be retrieved.
      * @return A `Flow` of `GitHubResponse<LocalGitHubRepository?>` objects. The emitted responses indicate the outcome:
      *   - `Success` containing a `LocalGitHubRepository` object representing the retrieved github repository,
      *     or null if no github repository is found.
      *   - `Error` containing an error message if any exception occurred during the retrieval process.
      */
     fun getSelectedGitHubRepositoryFromDatabase(): Flow<GitHubResponse<LocalGitHubRepository?>>
+
+    /**
+     * Suspend function that saves selected Github repository in to My saved list.
+     * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
+     *
+     * The emitted responses can be of the following types:
+     *  * `Success`: Contains a [Boolean] value with the save results.
+     *               The response contains `True` if selected Github repository is saved successfully in local database.
+     *  * `Error`: Indicates an error occurred during the saving process. The response contains an error message.
+     *
+     * @param savedGitHubRepository The Github repository object to be saved in local database.
+     * @return A [Flow] of [GitHubResponse] objects representing the outcome of the save request.
+     *
+     * @throws Exception Catches unexpected exceptions that might occur during the operation.
+     */
+    suspend fun addGitHubRepositoryToMySavedList(savedGitHubRepository: SavedGitHubRepository): Flow<GitHubResponse<Boolean>>
+
+    /**
+     * Suspend function that deleted selected Github repository from My saved list in database.
+     * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
+     *
+     * The emitted responses can be of the following types:
+     *  * `Success`: Contains a [Boolean] value with the delete results.
+     *               The response contains `True` if selected Github repository is deleted successfully from local database.
+     *  * `Error`: Indicates an error occurred during the deleting process. The response contains an error message.
+     *
+     * @param savedGitHubRepository The Github repository object to be deleted from local database.
+     * @return A [Flow] of [GitHubResponse] objects representing the outcome of the delete request.
+     *
+     * @throws Exception Catches unexpected exceptions that might occur during the operation.
+     */
+    suspend fun removeGitHubRepositoryFromMySavedList(savedGitHubRepository: SavedGitHubRepository): Flow<GitHubResponse<Boolean>>
+
+    /**
+     * Suspend function that fetches a list `SavedGitHubRepository` objects from the database.
+     * This `SavedGitHubRepository` represents a GitHub repository added to My saved list.
+     *
+     * @return A `Flow` of `GitHubResponse<List<SavedGitHubRepository>>` object. The emitted responses indicate the outcome:
+     *   - `Success` containing a list of `SavedGitHubRepository` objects representing the My saved list.
+     *   - `Error` containing an error message if any exception occurred during the retrieval process.
+     */
+    suspend fun getMySavedList(): Flow<GitHubResponse<List<SavedGitHubRepository>>>
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package jp.co.yumemi.android.code_check.repository
 
-import android.util.Log
 import jp.co.yumemi.android.code_check.constant.ResponseCode.EXCEPTION
 import jp.co.yumemi.android.code_check.database.GitHubRepositoryDao
 import jp.co.yumemi.android.code_check.logger.Logger
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -76,6 +76,93 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
                 val errorMessage =
                     "An unexpected error occurred while retrieving selected github repository: ${ex.message}"
                 logger.error(TAG, errorMessage, ex)
+            }
+        }
+    }
+
+    /**
+     * Suspend function that saves selected Github repository in to My saved list.
+     * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
+     *
+     * The emitted responses can be of the following types:
+     *  * `Success`: Contains a [Boolean] value with the save results.
+     *               The response contains `True` if selected Github repository is saved successfully in local database.
+     *  * `Error`: Indicates an error occurred during the saving process. The response contains an error message.
+     *
+     * @param savedGitHubRepository The Github repository object to be saved in local database.
+     * @return A [Flow] of [GitHubResponse] objects representing the outcome of the save request.
+     *
+     * @throws Exception Catches unexpected exceptions that might occur during the operation.
+     */
+    override suspend fun addGitHubRepositoryToMySavedList(savedGitHubRepository: SavedGitHubRepository): Flow<GitHubResponse<Boolean>> {
+        return withContext(Dispatchers.IO) {
+            return@withContext flow {
+                emit(GitHubResponse.Loading) // Indicate loading state
+                try {
+                    gitHubRepositoryDao.insertSavedGitHubRepository(savedGitHubRepository)
+                    emit(GitHubResponse.Success(true))
+                } catch (ex: Exception) {
+                    emit(GitHubResponse.Error(EXCEPTION))
+                    val errorMessage =
+                        "An unexpected error occurred while saving selected github repository: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                }
+            }
+        }
+    }
+
+    /**
+     * Suspend function that deleted selected Github repository from My saved list in database.
+     * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
+     *
+     * The emitted responses can be of the following types:
+     *  * `Success`: Contains a [Boolean] value with the delete results.
+     *               The response contains `True` if selected Github repository is deleted successfully from local database.
+     *  * `Error`: Indicates an error occurred during the deleting process. The response contains an error message.
+     *
+     * @param savedGitHubRepository The Github repository object to be deleted from local database.
+     * @return A [Flow] of [GitHubResponse] objects representing the outcome of the delete request.
+     *
+     * @throws Exception Catches unexpected exceptions that might occur during the operation.
+     */
+    override suspend fun removeGitHubRepositoryFromMySavedList(savedGitHubRepository: SavedGitHubRepository): Flow<GitHubResponse<Boolean>> {
+        return withContext(Dispatchers.IO) {
+            return@withContext flow {
+                emit(GitHubResponse.Loading) // Indicate loading state
+                try {
+                    gitHubRepositoryDao.deleteSavedGitHubRepository(savedGitHubRepository)
+                    emit(GitHubResponse.Success(true))
+                } catch (ex: Exception) {
+                    emit(GitHubResponse.Error(EXCEPTION))
+                    val errorMessage =
+                        "An unexpected error occurred while deleting the saved github repository: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                }
+            }
+        }
+    }
+
+    /**
+     * Suspend function that fetches a list `SavedGitHubRepository` objects from the database.
+     * This `SavedGitHubRepository` represents a GitHub repository added to My saved list.
+     *
+     * @return A `Flow` of `GitHubResponse<List<SavedGitHubRepository>>` object. The emitted responses indicate the outcome:
+     *   - `Success` containing a list of `SavedGitHubRepository` objects representing the My saved list.
+     *   - `Error` containing an error message if any exception occurred during the retrieval process.
+     */
+    override suspend fun getMySavedList(): Flow<GitHubResponse<List<SavedGitHubRepository>>> {
+        return withContext(Dispatchers.IO) {
+            return@withContext flow {
+                emit(GitHubResponse.Loading) // Indicate loading state
+                try {
+                    val response = gitHubRepositoryDao.getSavedGitHubRepositories()
+                    emit(GitHubResponse.Success(response))
+                } catch (ex: Exception) {
+                    emit(GitHubResponse.Error(EXCEPTION))
+                    val errorMessage =
+                        "An unexpected error occurred while retrieving My saved list: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/LocalGitHubDatabaseRepositoryImpl.kt
@@ -1,6 +1,9 @@
 package jp.co.yumemi.android.code_check.repository
 
+import android.util.Log
 import jp.co.yumemi.android.code_check.constant.ResponseCode.EXCEPTION
+import jp.co.yumemi.android.code_check.constant.ResponseCode.IOEXCEPTION
+import jp.co.yumemi.android.code_check.constant.ResponseCode.TIMEOUT_EXCEPTION
 import jp.co.yumemi.android.code_check.database.GitHubRepositoryDao
 import jp.co.yumemi.android.code_check.logger.Logger
 import jp.co.yumemi.android.code_check.model.GitHubResponse
@@ -10,6 +13,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.net.SocketTimeoutException
 import javax.inject.Inject
 
 /**
@@ -44,7 +49,18 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
                 try {
                     gitHubRepositoryDao.insertGitHubRepository(localGitHubRepository)
                     emit(GitHubResponse.Success(true))
+                } catch (ex: IOException) {
+                    // Emit a failure result for network errors
+                    emit(GitHubResponse.Error(IOEXCEPTION))
+                    val errorMessage = "Network error occurred: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                } catch (ex: SocketTimeoutException) {
+                    // Emit a failure result for connection timeout errors
+                    emit(GitHubResponse.Error(TIMEOUT_EXCEPTION))
+                    val errorMessage = "Connection timed out: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
                 } catch (ex: Exception) {
+                    // Emit a failure result for unexpected errors
                     emit(GitHubResponse.Error(EXCEPTION))
                     val errorMessage =
                         "An unexpected error occurred while saving selected github repository: ${ex.message}"
@@ -71,6 +87,16 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
                 val response =
                     gitHubRepositoryDao.getSelectedGitHubRepository()
                 emit(GitHubResponse.Success(response))
+            } catch (ex: IOException) {
+                // Emit a failure result for network errors
+                emit(GitHubResponse.Error(IOEXCEPTION))
+                val errorMessage = "Network error occurred: ${ex.message}"
+                logger.error(TAG, errorMessage, ex)
+            } catch (ex: SocketTimeoutException) {
+                // Emit a failure result for connection timeout errors
+                emit(GitHubResponse.Error(TIMEOUT_EXCEPTION))
+                val errorMessage = "Connection timed out: ${ex.message}"
+                logger.error(TAG, errorMessage, ex)
             } catch (ex: Exception) {
                 emit(GitHubResponse.Error(EXCEPTION))
                 val errorMessage =
@@ -81,7 +107,7 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
     }
 
     /**
-     * Suspend function that saves selected Github repository in to My saved list.
+     * Suspend function that saves selected Github repository in to user's saved list.
      * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
      *
      * The emitted responses can be of the following types:
@@ -101,6 +127,16 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
                 try {
                     gitHubRepositoryDao.insertSavedGitHubRepository(savedGitHubRepository)
                     emit(GitHubResponse.Success(true))
+                } catch (ex: IOException) {
+                    // Emit a failure result for network errors
+                    emit(GitHubResponse.Error(IOEXCEPTION))
+                    val errorMessage = "Network error occurred: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                } catch (ex: SocketTimeoutException) {
+                    // Emit a failure result for connection timeout errors
+                    emit(GitHubResponse.Error(TIMEOUT_EXCEPTION))
+                    val errorMessage = "Connection timed out: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
                 } catch (ex: Exception) {
                     emit(GitHubResponse.Error(EXCEPTION))
                     val errorMessage =
@@ -112,7 +148,7 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
     }
 
     /**
-     * Suspend function that deleted selected Github repository from My saved list in database.
+     * Suspend function that deleted selected Github repository from user's saved list in database.
      * This method utilizes Kotlin coroutines and returns a [Flow] of [GitHubResponse] objects.
      *
      * The emitted responses can be of the following types:
@@ -132,6 +168,16 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
                 try {
                     gitHubRepositoryDao.deleteSavedGitHubRepository(savedGitHubRepository)
                     emit(GitHubResponse.Success(true))
+                } catch (ex: IOException) {
+                    // Emit a failure result for network errors
+                    emit(GitHubResponse.Error(IOEXCEPTION))
+                    val errorMessage = "Network error occurred: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                } catch (ex: SocketTimeoutException) {
+                    // Emit a failure result for connection timeout errors
+                    emit(GitHubResponse.Error(TIMEOUT_EXCEPTION))
+                    val errorMessage = "Connection timed out: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
                 } catch (ex: Exception) {
                     emit(GitHubResponse.Error(EXCEPTION))
                     val errorMessage =
@@ -144,10 +190,10 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
 
     /**
      * Suspend function that fetches a list `SavedGitHubRepository` objects from the database.
-     * This `SavedGitHubRepository` represents a GitHub repository added to My saved list.
+     * This `SavedGitHubRepository` represents a GitHub repository added to user's saved list.
      *
      * @return A `Flow` of `GitHubResponse<List<SavedGitHubRepository>>` object. The emitted responses indicate the outcome:
-     *   - `Success` containing a list of `SavedGitHubRepository` objects representing the My saved list.
+     *   - `Success` containing a list of `SavedGitHubRepository` objects representing the user's saved list.
      *   - `Error` containing an error message if any exception occurred during the retrieval process.
      */
     override suspend fun getMySavedList(): Flow<GitHubResponse<List<SavedGitHubRepository>>> {
@@ -157,10 +203,20 @@ class LocalGitHubDatabaseRepositoryImpl @Inject constructor(
                 try {
                     val response = gitHubRepositoryDao.getSavedGitHubRepositories()
                     emit(GitHubResponse.Success(response))
+                } catch (ex: IOException) {
+                    // Emit a failure result for network errors
+                    emit(GitHubResponse.Error(IOEXCEPTION))
+                    val errorMessage = "Network error occurred: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
+                } catch (ex: SocketTimeoutException) {
+                    // Emit a failure result for connection timeout errors
+                    emit(GitHubResponse.Error(TIMEOUT_EXCEPTION))
+                    val errorMessage = "Connection timed out: ${ex.message}"
+                    logger.error(TAG, errorMessage, ex)
                 } catch (ex: Exception) {
                     emit(GitHubResponse.Error(EXCEPTION))
                     val errorMessage =
-                        "An unexpected error occurred while retrieving My saved list: ${ex.message}"
+                        "An unexpected error occurred while retrieving user's saved list: ${ex.message}"
                     logger.error(TAG, errorMessage, ex)
                 }
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/ErrorScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/ErrorScreen.kt
@@ -24,11 +24,12 @@ import jp.co.yumemi.android.code_check.constant.ResponseCode.IOEXCEPTION
 import jp.co.yumemi.android.code_check.constant.ResponseCode.TIMEOUT_EXCEPTION
 
 /**
- * Composable function for displaying an error screen with a title, error message, and retry button.
+ * Composable function for rendering an error message.
+ * This function displays an error title, error message, and a retry button.
  *
- * @param errorTitle The title of the error message.
- * @param errorMessage The detailed error message.
- * @param onRetryButtonClicked Callback to handle the retry button click.
+ * @param errorTitle The resource ID of the error title.
+ * @param errorCode Optional error code to determine the error message.
+ * @param onRetryButtonClicked Callback function to handle the retry button click.
  */
 @Composable
 fun ErrorScreen(
@@ -51,7 +52,7 @@ fun ErrorScreen(
 }
 
 /**
- * Function to retrieve localized error message for the provided error code.
+ * Function to retrieve the localized error message for the provided error code.
  *
  * @param errorCode The error code to determine the error message.
  * @return The resource ID of the corresponding error message.
@@ -110,6 +111,7 @@ fun LoadErrorSection(
 
 /**
  * Preview function for the ErrorScreen composable, used for Compose UI preview.
+ * This is useful during the development process.
  */
 @Preview(showBackground = true, showSystemUi = true)
 @Composable

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/GitHubRepositoryInfoScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/GitHubRepositoryInfoScreen.kt
@@ -2,24 +2,24 @@ package jp.co.yumemi.android.code_check.ui.compose
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -32,8 +32,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
@@ -44,138 +46,147 @@ import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
 import jp.co.yumemi.android.code_check.viewModel.GitHubRepositoryInfoViewModel
 
 /**
- * Composable that displays a preview of a repository.
+ * Composable function for displaying the GitHub repository information screen.
+ * This screen shows detailed information about a GitHub repository.
  *
- * @param modifier Modifier for customizing the layout.
+ * @param modifier Modifier for adjusting the layout of this composable.
+ * @param gitHubRepositoryInfoViewModel ViewModel for managing the state and logic of information screen.
  */
 @Composable
 fun GitHubRepositoryInfoScreen(
     modifier: Modifier = Modifier,
     gitHubRepositoryInfoViewModel: GitHubRepositoryInfoViewModel = hiltViewModel()
 ) {
+    // Collecting GitHub repository information state
     val gitHubRepositoryInfoState =
         gitHubRepositoryInfoViewModel.gitHubRepositoryInfo.collectAsState(initial = null)
 
-    gitHubRepositoryInfoState.let {
-        it.value?.let { repositoryInfoState ->
-            GitHubRepositoryMainInfoSection(
-                repositoryInfoState = repositoryInfoState,
-                onSaveButtonClick = gitHubRepositoryInfoViewModel::addGitHubRepositoryToMySavedList,
-                onUnSaveButtonClick = gitHubRepositoryInfoViewModel::removeGitHubRepositoryFromMySavedList,
-                modifier = modifier
-            )
-        }
-    }
-}
-
-@Composable
-fun GitHubRepositoryMainInfoSection(
-    repositoryInfoState: GitHubResponse<LocalGitHubRepository?>,
-    onSaveButtonClick: (localGitHubRepository: LocalGitHubRepository, onSuccess: () -> Unit, onError: (String?) -> Unit, onLoading: () -> Unit) -> Unit,
-    onUnSaveButtonClick: (localGitHubRepository: LocalGitHubRepository, onSuccess: () -> Unit, onError: (String?) -> Unit, onLoading: () -> Unit) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    if (repositoryInfoState is GitHubResponse.Success) {
-        repositoryInfoState.data?.let {
-            LazyColumn(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = modifier.padding(horizontal = dimensionResource(id = R.dimen.dp_10))
-            ) {
-                item {
-                    SaveToMySavedListSection(
-                        repository = it,
-                        onSaveButtonClick = onSaveButtonClick,
-                        onUnSaveButtonClick = onUnSaveButtonClick
+    // Checking if the fetched data is successfully received
+    if (gitHubRepositoryInfoState.value is GitHubResponse.Success) {
+        val gitHubRepositoryInfoResult = gitHubRepositoryInfoState.value as GitHubResponse.Success
+        gitHubRepositoryInfoResult.data?.let { repository ->
+            Scaffold(
+                topBar = {
+                    GithubRepoAppTopAppBar(
+                        title = R.string.info_screen_title,
+                        description = R.string.info_screen_description,
+                        modifier = modifier,
+                        isFilled = false
                     )
-                }
-                item {
-                    ImageSection(ownerAvatarUrl = it.ownerAvatarUrl)
-                }
-                item {
-                    InfoSection(repository = it)
+                },
+                bottomBar = {
+                    // Bottom app bar for displaying save/unsave button
+                    var isSaved by remember { mutableStateOf(false) }
+                    isSaved = repository.isSaved
+
+                    // Track save operation loading state
+                    var isSaveResponseLoading by remember { mutableStateOf(false) }
+
+                    // Callback function to handle the save button click
+                    val onSaveButtonClick =
+                        gitHubRepositoryInfoViewModel::addGitHubRepositoryToMySavedList
+
+                    // Callback function to handle the remove from saved button click
+                    val onUnSaveButtonClick =
+                        gitHubRepositoryInfoViewModel::removeGitHubRepositoryFromMySavedList
+                    BottomAppBar(
+                        actions = {
+                            Row(
+                                horizontalArrangement = Arrangement.Center,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                // Button for saving/unsaving repository
+                                TextButton(
+                                    onClick = {
+                                        // Only allow saving operation when not loading
+                                        if (!isSaveResponseLoading) {
+                                            isSaved = !isSaved
+                                            if (isSaved) {
+                                                // Call to add GitHub repository to user's saved list
+                                                onSaveButtonClick(
+                                                    repository,
+                                                    {
+                                                        // Reset loading state on success
+                                                        isSaveResponseLoading = false
+                                                    },
+                                                    {
+                                                        // Reset loading state on error
+                                                        isSaveResponseLoading = false
+
+                                                        // Revert the saved status on error
+                                                        isSaved = !isSaved
+                                                    },
+                                                    {
+                                                        // Set loading state on loading
+                                                        isSaveResponseLoading = true
+                                                    }
+                                                )
+                                            } else {
+                                                // Call to remove GitHub repository from user's saved list
+                                                onUnSaveButtonClick(
+                                                    repository,
+                                                    {
+                                                        // Reset loading state on success
+                                                        isSaveResponseLoading = false
+                                                    },
+                                                    {
+                                                        // Reset loading state on error
+                                                        isSaveResponseLoading = false
+
+                                                        // Revert the saved status on error
+                                                        isSaved = !isSaved
+                                                    },
+                                                    {
+                                                        // Set loading state on loading
+                                                        isSaveResponseLoading = true
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    }) {
+                                    Icon(
+                                        painter = if (isSaved) painterResource(id = R.drawable.baseline_bookmark_remove_24) else painterResource(
+                                            id = R.drawable.baseline_bookmark_add_24
+                                        ),
+                                        contentDescription = if (isSaved) stringResource(id = R.string.unsave) else stringResource(
+                                            id = R.string.save
+                                        ),
+                                        modifier = Modifier.size(ButtonDefaults.IconSize)
+                                    )
+                                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+                                    Text(
+                                        text = if (isSaved) stringResource(id = R.string.unsave) else stringResource(
+                                            id = R.string.save
+                                        )
+                                    )
+                                }
+                            }
+                        },
+                    )
+                },
+            ) { padding ->
+                LazyColumn(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = modifier.padding(padding)
+                ) {
+                    // Displaying repository image section
+                    item {
+                        ImageSection(ownerAvatarUrl = repository.ownerAvatarUrl)
+                    }
+                    // Displaying repository information section
+                    item {
+                        InfoSection(repository = repository)
+                    }
                 }
             }
         }
     }
 }
 
-@Composable
-fun SaveToMySavedListSection(
-    repository: LocalGitHubRepository,
-    onSaveButtonClick: (localGitHubRepository: LocalGitHubRepository, onSuccess: () -> Unit, onError: (String?) -> Unit, onLoading: () -> Unit) -> Unit,
-    onUnSaveButtonClick: (localGitHubRepository: LocalGitHubRepository, onSuccess: () -> Unit, onError: (String?) -> Unit, onLoading: () -> Unit) -> Unit,
-) {
-    Surface(
-
-    ) {
-        var isSaved by remember { mutableStateOf(false) }
-        isSaved = repository.isSaved
-
-        // Track save operation loading state
-        var isSaveResponseLoading by remember { mutableStateOf(false) }
-        ElevatedButton(
-            onClick = {
-                // Only allow saving operation when not loading
-                if (!isSaveResponseLoading) {
-                    isSaved = !isSaved
-                    if (isSaved) {
-                        // Call to add GitHub repository to user's saved list
-                        onSaveButtonClick(
-                            repository,
-                            {
-                                // Reset loading state on success
-                                isSaveResponseLoading = false
-                            },
-                            {
-                                // Reset loading state on error
-                                isSaveResponseLoading = false
-
-                                // Revert the saved status on error
-                                isSaved = !isSaved
-                            },
-                            {
-                                // Set loading state on loading
-                                isSaveResponseLoading = true
-                            }
-                        )
-                    } else {
-                        // Call to remove GitHub repository from user's saved list
-                        onUnSaveButtonClick(
-                            repository,
-                            {
-                                // Reset loading state on success
-                                isSaveResponseLoading = false
-                            },
-                            {
-                                // Reset loading state on error
-                                isSaveResponseLoading = false
-
-                                // Revert the saved status on error
-                                isSaved = !isSaved
-                            },
-                            {
-                                // Set loading state on loading
-                                isSaveResponseLoading = true
-                            }
-                        )
-                    }
-                }
-            }) {
-            Icon(
-                imageVector = if (isSaved) Icons.Default.FavoriteBorder else Icons.Filled.Favorite,
-                contentDescription = if (isSaved) "Save me" else "Unsave me",
-                modifier = Modifier.size(ButtonDefaults.IconSize)
-            )
-            Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
-            Text(text = if (isSaved) "Unsave me" else "Save me")
-        }
-    }
-}
-
 /**
- * Composable that displays the image of the repository owner's avatar.
+ * Composable function for displaying the image of the repository owner's avatar.
  *
- * @param owner The owner of the repository. If null, a placeholder image is displayed.
+ * @param ownerAvatarUrl The URL of the repository owner's avatar image.
  */
 @Composable
 fun ImageSection(
@@ -199,23 +210,22 @@ fun ImageSection(
 }
 
 /**
- * Composable that displays the information section of the repository preview.
+ * Composable function for displaying the information section of the repository.
  *
- * @param repository The repository item to display information for.
+ * @param repository The repository item containing information to display.
  */
 @Composable
 fun InfoSection(
     repository: LocalGitHubRepository
 ) {
-    RepositoryTitleNameSection(repository.name)
-    Column(
-        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.dp_20))
-    ) {
-        OwnerLoginSection(repository.ownerLogin)
-    }
     Column(
         modifier = Modifier.padding(dimensionResource(id = R.dimen.dp_20))
     ) {
+        // Displaying repository name
+        RepositoryTitleNameSection(repository.name)
+        // Displaying owner login name
+        OwnerLoginSection(repository.ownerLogin)
+        // Displaying data fields (language, stars count, watchers count, fork count, open issue count)
         DataField(
             title = stringResource(R.string.written_language),
             value = repository.language,
@@ -237,7 +247,8 @@ fun InfoSection(
             value = repository.openIssuesCount.toString(),
         )
     }
-    Column(
+    // Displaying button to navigate to repository URL
+    Row(
         modifier = Modifier.padding(bottom = dimensionResource(id = R.dimen.dp_20))
     ) {
         GoToUrlSection(repository.htmlUrl)
@@ -245,9 +256,9 @@ fun InfoSection(
 }
 
 /**
- * Composable that displays the name of the repository.
+ * Composable function for displaying the name of the repository.
  *
- * @param name The name of the repository. If null, nothing is displayed.
+ * @param name The name of the repository.
  */
 @Composable
 fun RepositoryTitleNameSection(name: String?) {
@@ -256,20 +267,27 @@ fun RepositoryTitleNameSection(name: String?) {
             text = name,
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Bold,
-            modifier = Modifier.testTag("PreviewRepositoryTitle")
+            modifier = Modifier
+                .testTag("PreviewRepositoryTitle")
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center
         )
     }
 }
 
 /**
- * Composable that displays the login name of the repository owner.
+ * Composable function for displaying the login name of the repository owner.
  *
- * @param owner The owner of the repository. If null, a default null value is displayed.
+ * @param ownerLoginName The login name of the repository owner.
  */
 @Composable
 fun OwnerLoginSection(ownerLoginName: String?) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .padding(vertical = dimensionResource(id = R.dimen.dp_20))
+            .fillMaxWidth()
     ) {
         Text(
             text = stringResource(R.string.by),
@@ -285,10 +303,10 @@ fun OwnerLoginSection(ownerLoginName: String?) {
 }
 
 /**
- * Composable that displays a field of data.
+ * Composable function for displaying a field of data.
  *
  * @param title The title of the data field.
- * @param value The value to display. If null, a default null value is displayed.
+ * @param value The value to display.
  */
 @Composable
 fun DataField(
@@ -319,9 +337,9 @@ fun DataField(
 }
 
 /**
- * Composable that displays a button to navigate to Github repository.
+ * Composable function for displaying a button to navigate to the GitHub repository URL.
  *
- * @param url The URL of Github repository to navigate to. If null, the button is not displayed.
+ * @param url The URL of the GitHub repository.
  */
 @Composable
 fun GoToUrlSection(url: String?) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/GithubRepoTopAppBar.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/GithubRepoTopAppBar.kt
@@ -1,20 +1,61 @@
 package jp.co.yumemi.android.code_check.ui.compose
 
-import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import jp.co.yumemi.android.code_check.R
+import androidx.compose.ui.text.style.TextOverflow
+import jp.co.yumemi.android.code_check.ui.theme.Typography
 
+/**
+ * Composable function for displaying a custom top app bar for the GitHub repository app.
+ * This top app bar contains the title and description of the screen.
+ *
+ * @param title Resource ID for the title string displayed in the top app bar.
+ * @param description Resource ID for the description string displayed in the top app bar.
+ * @param modifier Modifier for adjusting the layout of this composable.
+ * @param isFilled Boolean indicating whether the top app bar should have a filled background.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GithubRepoAppTopAppBar(){
-    CenterAlignedTopAppBar(
+fun GithubRepoAppTopAppBar(
+    @StringRes title: Int,
+    @StringRes description: Int,
+    modifier: Modifier = Modifier,
+    isFilled: Boolean = true
+) {
+    TopAppBar(
         title = {
-            Text(
-                text = stringResource(id = R.string.app_name),
-            )
-        }
+            Column {
+                Text(
+                    stringResource(id = title),
+                    style = Typography.titleLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    stringResource(id = description),
+                    style = Typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        modifier = modifier,
+        // Customizing top app bar colors based on whether it should have a filled background
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = if (isFilled) {
+                MaterialTheme.colorScheme.surface
+            } else {
+                Color.Transparent
+            }
+        ),
     )
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/LoadingScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/LoadingScreen.kt
@@ -68,7 +68,8 @@ fun LoadingAnimation(
                 durationMillis = animationDuration,
                 easing = LinearEasing
             )
-        ), label = stringResource(id = R.string.loading)
+        ),
+        label = stringResource(id = R.string.loading)
     )
 
     CircularProgressIndicator(

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/MainActivity.kt
@@ -6,9 +6,9 @@ package jp.co.yumemi.android.code_check.ui.compose
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
@@ -26,20 +26,16 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GithubRepositoryApp() {
     GithubRepositoryAppTheme {
         val navController = rememberNavController()
-        Scaffold(
-            topBar = {
-                GithubRepoAppTopAppBar()
-            },
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
             content = {
                 // Host the navigation flow of the app
-                AppNavHost(
-                    navController = navController, modifier = Modifier.padding(it)
-                )
+                AppNavHost(navController = navController)
             }
         )
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/MainActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,6 +15,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.ui.compose.navigation.AppNavHost
 import jp.co.yumemi.android.code_check.ui.theme.GithubRepositoryAppTheme
 
+/**
+ * An activity serving as the entry point of the application.
+ * This activity hosts the Jetpack Compose UI for the Github Repository App.
+ */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,13 +29,16 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+/**
+ * The main Composable function for the Github Repository App.
+ * This function sets up the theme and navigation for the entire app.
+ */
 @Composable
 fun GithubRepositoryApp() {
     GithubRepositoryAppTheme {
         val navController = rememberNavController()
         Surface(
             modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background,
             content = {
                 // Host the navigation flow of the app
                 AppNavHost(navController = navController)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/MySavedListScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/MySavedListScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -14,245 +13,35 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.model.GitHubRepository
 import jp.co.yumemi.android.code_check.model.GitHubRepositoryOwner
-import jp.co.yumemi.android.code_check.model.GitHubResponse
-import jp.co.yumemi.android.code_check.viewModel.HomeViewModel
 
-/**
- * Composable function representing the main screen of the app.
- *
- * @param navigateToGitHubRepositoryInfo Callback function when a repository item is clicked.
- * @param modifier Modifier for customizing the layout.
- */
 @Composable
-fun HomeScreen(
+fun MySavedListScreen(
     modifier: Modifier = Modifier,
-    homeViewModel: HomeViewModel = hiltViewModel(),
-    navigateToGitHubRepositoryInfo: () -> Unit,
-    onMySavedListButtonClick: () -> Unit
+
 ) {
-    val gitHubSearchResultState = homeViewModel.gitHubSearchResultState.collectAsState()
-    val isSelectedGitHubRepositorySavedState =
-        homeViewModel.isSelectedGitHubRepositorySavedState.collectAsState()
-    val keyboardController = LocalSoftwareKeyboardController.current
 
-    // State variable to hold the navigation condition
-    var shouldNavigateToGitHubRepositoryInfo by remember { mutableStateOf(false) }
-
-    Scaffold(
-        topBar = {
-            GithubRepoAppTopAppBar()
-        },
-        floatingActionButton = {
-            MySavedListButton(onMySavedListButtonClick)
-        }
-    ) { padding ->
-        Column(
-            modifier = modifier
-                .padding(padding)
-        ) {
-            SearchSection(
-                searchKeyword = homeViewModel.searchKeyword,
-                onSearchKeywordChange = { homeViewModel.updateSearchKeyword(it) },
-                onSearchClicked = {
-                    keyboardController?.hide()
-                    homeViewModel.searchGitHubRepositories()
-                },
-                onClearButtonClicked = { homeViewModel.clearSearchKeyword() },
-            )
-
-            when (gitHubSearchResultState.value) {
-                is GitHubResponse.Loading -> {
-                    LoadingScreen()
-                }
-
-                is GitHubResponse.Error -> {
-                    ErrorScreen(
-                        errorTitle = R.string.oh_no,
-                        errorCode = (gitHubSearchResultState.value as GitHubResponse.Error).error,
-                        onRetryButtonClicked = { homeViewModel.searchGitHubRepositories() }
-                    )
-                }
-
-                is GitHubResponse.Success -> {
-                    val gitHubSearchResult = gitHubSearchResultState.value as GitHubResponse.Success
-                    SearchResultSection(
-                        repositoryList = gitHubSearchResult.data.items,
-                        onGitHubRepositoryClicked = { selectedGitHubRepository ->
-                            homeViewModel.saveSelectedGitHubRepositoryInDatabase(
-                                selectedGitHubRepository
-                            )
-                            shouldNavigateToGitHubRepositoryInfo = true
-                        }
-                    )
-                }
-            }
-        }
-    }
-
-    // Check if navigation is required and perform navigation
-    if (shouldNavigateToGitHubRepositoryInfo) {
-        if (isSelectedGitHubRepositorySavedState.value is GitHubResponse.Success) {
-            navigateToGitHubRepositoryInfo()
-            shouldNavigateToGitHubRepositoryInfo = false // Reset flag after navigation
-        } else if (isSelectedGitHubRepositorySavedState.value is GitHubResponse.Error) {
-            ErrorScreen(
-                errorTitle = R.string.oh_no,
-                errorCode = (gitHubSearchResultState.value as GitHubResponse.Error).error,
-                onRetryButtonClicked = { homeViewModel.searchGitHubRepositories() }
-            )
-        }
-    }
 }
 
 @Composable
-fun MySavedListButton(onMySavedListButtonClick: () -> Unit) {
-    FloatingActionButton(
-        shape = MaterialTheme.shapes.large.copy(CornerSize(percent = 50)),
-        onClick = onMySavedListButtonClick,
-        contentColor = MaterialTheme.colorScheme.primary,
-        containerColor = Color.Transparent,
-    ) {
-        Box(
-            modifier = Modifier
-                .size(56.dp, 56.dp)
-                .background(
-                    color = MaterialTheme.colorScheme.tertiary
-                ),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                Icons.Default.Star,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onTertiary
-            )
-        }
-    }
-}
+fun ShowMySavedList() {
 
-/**
- * Composable function for the search field section of the main screen.
- *
- * @param searchKeyword The search keyword.
- * @param onSearchKeywordChange Callback function for changes in the search keyword.
- * @param onSearchClicked Callback function for the search button click.
- * @param onClearButtonClicked Callback function for the clear button click.
- * @param modifier Modifier for customizing the layout.
- */
-@Composable
-fun SearchSection(
-    searchKeyword: String,
-    onSearchKeywordChange: (String) -> Unit,
-    onSearchClicked: () -> Unit,
-    onClearButtonClicked: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        verticalArrangement = Arrangement.Center,
-        modifier = Modifier.padding(dimensionResource(id = R.dimen.dp_10))
-    ) {
-        OutlinedTextField(
-            value = searchKeyword,
-            singleLine = true,
-            onValueChange = onSearchKeywordChange,
-            leadingIcon = {
-                SearchButton(onSearchClicked = onSearchClicked)
-            },
-            trailingIcon = {
-                if (searchKeyword.isNotBlank()) {
-                    ClearButton(onClearButtonClicked = onClearButtonClicked)
-                }
-            },
-            label = {
-                Text(text = stringResource(R.string.searchInputText_hint))
-            },
-            keyboardOptions = KeyboardOptions.Default.copy(
-                imeAction = ImeAction.Search
-            ),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    onSearchClicked()
-                }
-            ),
-            modifier = modifier
-                .fillMaxWidth()
-                .then(Modifier.testTag("SearchTextField"))
-        )
-    }
-}
-
-/**
- * Composable function for the search button.
- *
- * @param onSearchClicked Callback function for the search button click.
- */
-@Composable
-fun SearchButton(onSearchClicked: () -> Unit) {
-    IconButton(
-        onClick = { onSearchClicked() },
-        modifier = Modifier.testTag("SearchButton")
-    ) {
-        Icon(
-            imageVector = Icons.Default.Search,
-            contentDescription = stringResource(R.string.search_icon_description)
-        )
-    }
-}
-
-/**
- * Composable function for the clear button.
- *
- * @param onClearButtonClicked Callback function for the clear button click.
- */
-@Composable
-fun ClearButton(onClearButtonClicked: () -> Unit) {
-    IconButton(
-        onClick = { onClearButtonClicked() },
-        modifier = Modifier.testTag("ClearButton")
-    ) {
-        Icon(
-            imageVector = Icons.Default.Clear,
-            contentDescription = stringResource(R.string.clear_icon_description)
-        )
-    }
 }
 
 /**
@@ -262,7 +51,7 @@ fun ClearButton(onClearButtonClicked: () -> Unit) {
  * @param onGitHubRepositoryClicked Callback function when a single repository list item is clicked.
  */
 @Composable
-fun SearchResultSection(
+fun MySavedListSection(
     repositoryList: List<GitHubRepository>,
     onGitHubRepositoryClicked: (GitHubRepository) -> Unit,
 ) {
@@ -285,7 +74,7 @@ fun SearchResultSection(
             )
         ) {
             items(items = repositoryList) {
-                RepositoryListItem(
+                MySavedListItem(
                     githubRepository = it,
                     onGitHubRepositoryClicked = onGitHubRepositoryClicked
                 )
@@ -301,7 +90,7 @@ fun SearchResultSection(
  * @param onGitHubRepositoryClicked Callback function when this item is clicked.
  */
 @Composable
-fun RepositoryListItem(
+fun MySavedListItem(
     githubRepository: GitHubRepository,
     onGitHubRepositoryClicked: (GitHubRepository) -> Unit
 ) {
@@ -323,8 +112,8 @@ fun RepositoryListItem(
             modifier = Modifier
                 .padding(dimensionResource(id = R.dimen.dp_10))
         ) {
-            RepositoryNameSection(githubRepository.name)
-            OwnerSection(githubRepository.owner)
+            MySavedRepositoryNameSection(githubRepository.name)
+            MySavedRepositoryOwnerSection(githubRepository.owner)
             HorizontalDivider(
                 modifier = Modifier.padding(
                     top = dimensionResource(id = R.dimen.dp_8),
@@ -332,7 +121,7 @@ fun RepositoryListItem(
                 ),
                 thickness = dimensionResource(id = R.dimen.dp_1)
             )
-            LanguageAndStatisticsSection(
+            MySavedRepositoryLanguageAndStatisticsSection(
                 language = githubRepository.language,
                 watchersCount = githubRepository.watchersCount,
                 stargazersCount = githubRepository.stargazersCount
@@ -347,7 +136,7 @@ fun RepositoryListItem(
  * @param name The name of the repository. If null, nothing is displayed.
  */
 @Composable
-fun RepositoryNameSection(name: String?) {
+fun MySavedRepositoryNameSection(name: String?) {
     name?.let {
         Text(
             text = name,
@@ -364,7 +153,7 @@ fun RepositoryNameSection(name: String?) {
  * @param owner The owner of the repository. If null, a default null value is displayed.
  */
 @Composable
-fun OwnerSection(owner: GitHubRepositoryOwner?) {
+fun MySavedRepositoryOwnerSection(owner: GitHubRepositoryOwner?) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -389,7 +178,7 @@ fun OwnerSection(owner: GitHubRepositoryOwner?) {
  * @param stargazersCount The number of stargazers for the repository. If null, a default null value is displayed.
  */
 @Composable
-fun LanguageAndStatisticsSection(
+fun MySavedRepositoryLanguageAndStatisticsSection(
     language: String?,
     watchersCount: Long?,
     stargazersCount: Long?

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppDestination.kt
@@ -2,6 +2,7 @@ package jp.co.yumemi.android.code_check.ui.compose.navigation
 
 import jp.co.yumemi.android.code_check.constant.NavigationArgument.DESTINATION_GITHUB_REPO_INFO
 import jp.co.yumemi.android.code_check.constant.NavigationArgument.DESTINATION_HOME
+import jp.co.yumemi.android.code_check.constant.NavigationArgument.DESTINATION_MY_SAVED_LIST
 
 /**
  * An interface that represents a navigation destination in the app.
@@ -21,11 +22,21 @@ object HomeDestination : AppDestination {
 }
 
 /**
- * An object representing the GitHub Repository Preview destination.
+ * An object representing the GitHub Repository info destination.
  */
 object GitHubRepositoryInfoDestination : AppDestination {
     /**
      * The route to the GitHub repository info screen.
      */
     override val route = DESTINATION_GITHUB_REPO_INFO
+}
+
+/**
+ * An object representing the My saved list destination.
+ */
+object MySavedListDestination : AppDestination {
+    /**
+     * The route to the My saved list screen.
+     */
+    override val route = DESTINATION_MY_SAVED_LIST
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppDestination.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppDestination.kt
@@ -32,11 +32,11 @@ object GitHubRepositoryInfoDestination : AppDestination {
 }
 
 /**
- * An object representing the My saved list destination.
+ * An object representing the user's saved list destination.
  */
 object MySavedListDestination : AppDestination {
     /**
-     * The route to the My saved list screen.
+     * The route to the user's saved list screen.
      */
     override val route = DESTINATION_MY_SAVED_LIST
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppNavHost.kt
@@ -65,6 +65,11 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
              * @param modifier Additional modifier to be applied to the composable.
              */
             MySavedListScreen(
+                navigateToGitHubRepositoryInfo = {
+                    navController.navigateSingleTopTo(
+                        GitHubRepositoryInfoDestination.route
+                    )
+                },
                 modifier = modifier
             )
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppNavHost.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/compose/navigation/AppNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import jp.co.yumemi.android.code_check.ui.compose.GitHubRepositoryInfoScreen
 import jp.co.yumemi.android.code_check.ui.compose.HomeScreen
+import jp.co.yumemi.android.code_check.ui.compose.MySavedListScreen
 
 /**
  * Composable function responsible for hosting the navigation flow of the app.
@@ -33,6 +34,11 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
                         GitHubRepositoryInfoDestination.route
                     )
                 },
+                onMySavedListButtonClick = {
+                    navController.navigateSingleTopTo(
+                        MySavedListDestination.route
+                    )
+                },
                 modifier = modifier,
             )
         }
@@ -46,6 +52,19 @@ fun AppNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
              * @param modifier Additional modifier to be applied to the composable.
              */
             GitHubRepositoryInfoScreen(
+                modifier = modifier
+            )
+        }
+        composable(
+            route = MySavedListDestination.route,
+        ) {
+            /**
+             * The composable screen for displaying GitHub repositories saved in the database for later reference.
+             * This screen is accessible by navigating to the route `${MySavedListDestination.route}/`
+             *
+             * @param modifier Additional modifier to be applied to the composable.
+             */
+            MySavedListScreen(
                 modifier = modifier
             )
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Color.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/theme/Color.kt
@@ -2,7 +2,7 @@ package jp.co.yumemi.android.code_check.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val md_theme_light_primary = Color(0xFF8B4483)
+val md_theme_light_primary = Color(0xFF380037)
 val md_theme_light_onPrimary = Color(0xFFFFFFFF)
 val md_theme_light_primaryContainer = Color(0xFFFFD7F4)
 val md_theme_light_onPrimaryContainer = Color(0xFF380037)
@@ -21,7 +21,7 @@ val md_theme_light_onErrorContainer = Color(0xFF410002)
 val md_theme_light_background = Color(0xFFFFFBFF)
 val md_theme_light_onBackground = Color(0xFF1F1A1D)
 val md_theme_light_surface = Color(0xFFB47DAE)
-val md_theme_light_onSurface = Color(0xFF1F1A1D)
+val md_theme_light_onSurface = Color(0xFF380037)
 val md_theme_light_surfaceVariant = Color(0xFFEEDEE7)
 val md_theme_light_onSurfaceVariant = Color(0xFF4E444B)
 val md_theme_light_outline = Color(0xFF72646C)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModel.kt
@@ -1,35 +1,128 @@
 package jp.co.yumemi.android.code_check.viewModel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.android.code_check.constant.ResponseCode
+import jp.co.yumemi.android.code_check.logger.Logger
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.toSavedGitHubRepository
 import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * A ViewModel class responsible for fetching and exposing information about a selected GitHub repository.
+ * ViewModel class responsible for fetching and exposing information about a selected GitHub repository.
  * This ViewModel retrieves the selected GitHub repository from the [LocalGitHubRepository] table in Room database.
  * The [LocalGitHubRepository] table contains only one row to store the most recently selected
- * github repository and that has fixed value (`1`) as the primary key.
+ * github repository by the user to see information and has fixed value (`1`) as the primary key.
  *
  * The retrieved information is exposed as a Flow of `GitHubResponse`, which can represent
  * either success with the repository details or an error if the repository is not found
  * or if an exception occurs during the retrieval process or null if the retrieved argument is null.
  *
  * @param localGitHubDatabaseRepository Repository providing access to local GitHub data.
+ * @param logger The logger for logging errors.
  */
 @HiltViewModel
 class GitHubRepositoryInfoViewModel @Inject constructor(
-    localGitHubDatabaseRepository: LocalGitHubDatabaseRepository,
+    private val localGitHubDatabaseRepository: LocalGitHubDatabaseRepository,
+    private val logger: Logger
 ) : ViewModel() {
-    /**
-     * Retrieves information about the selected GitHub repository as a Flow of [GitHubResponse].
-     * This Flow emits a [GitHubResponse] containing either:
-     *  - Success: The fetched [LocalGitHubRepository] data.
-     *  - Error: Information about an encountered error during data retrieval.
+    // Logging tag for this class
+    private val TAG = this.javaClass.simpleName
+
+    /*
+    Retrieves information about the selected GitHub repository as a Flow of [GitHubResponse].
+    This Flow emits a [GitHubResponse] containing either:
+     - Success: The fetched [LocalGitHubRepository] data.
+     - Error: Information about an encountered error during data retrieval.
      */
     val gitHubRepositoryInfo: Flow<GitHubResponse<LocalGitHubRepository?>> =
         localGitHubDatabaseRepository.getSelectedGitHubRepositoryFromDatabase()
+
+    /**
+     * Adds the specified [localGitHubRepository] to the user's saved list in the local database.
+     *
+     * @param localGitHubRepository The GitHub repository to be added to the saved list.
+     * @param onSuccess Callback invoked when the GitHub repository is successfully added.
+     * @param onError Callback invoked if an error occurs during the operation. It receives an error message as a parameter.
+     * @param onLoading Callback invoked when the operation is in progress.
+     */
+    fun addGitHubRepositoryToMySavedList(
+        localGitHubRepository: LocalGitHubRepository,
+        onSuccess: () -> Unit,
+        onError: (String?) -> Unit,
+        onLoading: () -> Unit
+    ) {
+        viewModelScope.launch {
+            try {
+                val savedGitHubRepository =
+                    localGitHubRepository.toSavedGitHubRepository(isSaved = true)
+
+                localGitHubDatabaseRepository.addGitHubRepositoryToMySavedList(savedGitHubRepository = savedGitHubRepository)
+                    .flowOn(Dispatchers.IO)
+                    .collect { addedResult ->
+                        when (addedResult) {
+                            is GitHubResponse.Success -> onSuccess()
+                            is GitHubResponse.Error -> onError(addedResult.error)
+                            is GitHubResponse.Loading -> onLoading()
+                        }
+                    }
+            } catch (ex: Exception) {
+                onError(ResponseCode.EXCEPTION)
+                logger.error(
+                    TAG,
+                    ex.message
+                        ?: "An error occurred while adding GitHub repository to user's saved list: ${localGitHubRepository.id}",
+                    ex
+                )
+            }
+        }
+    }
+
+    /**
+     * Removes the specified [localGitHubRepository] from the user's saved list in the local database.
+     *
+     * @param localGitHubRepository The GitHub repository to be removed from the saved list.
+     * @param onSuccess Callback invoked when the GitHub repository is successfully removed.
+     * @param onError Callback invoked if an error occurs during the operation. It receives an error message as a parameter.
+     * @param onLoading Callback invoked when the operation is in progress.
+     */
+    fun removeGitHubRepositoryFromMySavedList(
+        localGitHubRepository: LocalGitHubRepository,
+        onSuccess: () -> Unit,
+        onError: (String?) -> Unit,
+        onLoading: () -> Unit
+    ) {
+        viewModelScope.launch {
+            try {
+                val savedGitHubRepository =
+                    localGitHubRepository.toSavedGitHubRepository(isSaved = false)
+                localGitHubDatabaseRepository.removeGitHubRepositoryFromMySavedList(
+                    savedGitHubRepository = savedGitHubRepository
+                )
+                    .flowOn(Dispatchers.IO)
+                    .collect { removedResult ->
+                        when (removedResult) {
+                            is GitHubResponse.Success -> onSuccess()
+                            is GitHubResponse.Error -> onError(removedResult.error)
+                            is GitHubResponse.Loading -> onLoading()
+                        }
+                    }
+            } catch (ex: Exception) {
+                onError(ResponseCode.EXCEPTION)
+                logger.error(
+                    TAG,
+                    ex.message
+                        ?: "An error occurred while removing GitHub repository from user's saved list: ${localGitHubRepository.id}",
+                    ex
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModel.kt
@@ -1,10 +1,7 @@
 package jp.co.yumemi.android.code_check.viewModel
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jp.co.yumemi.android.code_check.constant.NavigationArgument.ARGUMENT_GITHUB_REPO_ID
-import jp.co.yumemi.android.code_check.logger.Logger
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
 import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModel.kt
@@ -8,10 +8,9 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.code_check.constant.ResponseCode.EXCEPTION
 import jp.co.yumemi.android.code_check.logger.Logger
-import jp.co.yumemi.android.code_check.model.GitHubRepository
-import jp.co.yumemi.android.code_check.model.GitHubRepositoryList
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.toLocalGitHubRepository
 import jp.co.yumemi.android.code_check.repository.GitHubApiRepository
 import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
 import kotlinx.coroutines.Dispatchers
@@ -22,10 +21,12 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * ViewModel class for the Home screen shared among Composable functions of HomeScreen and GitHubRepositoryInfoScreen.
- * Handles interactions between UI and data related to GitHub repositories.
+ * ViewModel class for managing the Home screen's UI state and interactions related to GitHub repositories.
+ * This ViewModel is shared among Composable functions of HomeScreen.
  *
  * @param gitHubApiRepository The repository for interacting with the GitHub API.
+ * @param localGitHubDatabaseRepository The repository for accessing local database operations related to GitHub repositories.
+ * @param logger The logger for logging errors.
  */
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -36,43 +37,70 @@ class HomeViewModel @Inject constructor(
     // Logging tag for this class
     private val TAG = this.javaClass.simpleName
 
-    // StateFlow for holding the outcome of GitHub repository searches.
-    // It emits [GitHubResponse] objects representing success, error, or loading state.
-    private val _gitHubSearchResultState = MutableStateFlow<GitHubResponse<GitHubRepositoryList>>(
-        GitHubResponse.Success(GitHubRepositoryList(emptyList()))
-    )
-    val gitHubSearchResultState: StateFlow<GitHubResponse<GitHubRepositoryList>> =
+    /*
+    StateFlow for holding the outcome of GitHub repository searches.
+    It emits [GitHubResponse] objects representing success, error, or loading state.
+     */
+    private val _gitHubSearchResultState =
+        MutableStateFlow<GitHubResponse<List<LocalGitHubRepository>>>(
+            GitHubResponse.Success(emptyList())
+        )
+    val gitHubSearchResultState: StateFlow<GitHubResponse<List<LocalGitHubRepository>>> =
         _gitHubSearchResultState
 
+    /*
+    StateFlow for holding the outcome of saving the selected GitHub repository in the database.
+    It emits [GitHubResponse] objects representing success, error, or loading state.
+    This saved GitHub repository data will be shown in `GitHubRepositoryInfoScreen`.
+     */
     private val _isSelectedGitHubRepositorySavedState =
         MutableStateFlow<GitHubResponse<Boolean>>(GitHubResponse.Loading)
     val isSelectedGitHubRepositorySavedState: StateFlow<GitHubResponse<Boolean>> =
         _isSelectedGitHubRepositorySavedState
 
-    //  Two-way data binding property for the user's search keyword.
+    // Holds user's search keyword.
     var searchKeyword by mutableStateOf("")
 
     /**
      * Initiates a search for GitHub repositories based on the current value of [searchKeyword].
-     *  - If the keyword is empty, a successful response with an empty list is emitted.
-     *  - Otherwise, it fetches repositories using the injected [gitHubApiRepository] and updates the UI accordingly.
+     * - If the keyword is empty, a successful response with an empty list is emitted.
+     * - Otherwise, it fetches repositories using the injected [gitHubApiRepository] and updates the UI accordingly.
      */
     fun searchGitHubRepositories() {
         _gitHubSearchResultState.value = GitHubResponse.Loading
         if (searchKeyword.isBlank()) {
             _gitHubSearchResultState.value =
-                GitHubResponse.Success(GitHubRepositoryList(emptyList()))
+                GitHubResponse.Success(emptyList())
         } else {
             viewModelScope.launch {
                 try {
                     gitHubApiRepository.searchGitHubRepositories(searchKeyword)
                         .flowOn(Dispatchers.IO)
-                        .collect {
-                            _gitHubSearchResultState.value = it
+                        .collect { gitHubResponse ->
+                            if (gitHubResponse is GitHubResponse.Success) {
+                                val searchedRepos = gitHubResponse.data.items
+                                // Fetch the user's saved GitHub repositories from the local database
+                                localGitHubDatabaseRepository.getMySavedList()
+                                    .flowOn(Dispatchers.IO)
+                                    .collect { databaseResponse ->
+                                        if (databaseResponse is GitHubResponse.Success) {
+                                            val savedRepos = databaseResponse.data
+                                            // Map each searched GitHub repository to update the isSaved property
+                                            val updatedRepos = searchedRepos.map { searchedRepo ->
+                                                val isSaved =
+                                                    savedRepos.any { savedRepo -> savedRepo.id == searchedRepo.id }
+                                                // Create a copy of the GitHub searched repository with the updated isSaved property
+                                                searchedRepo.toLocalGitHubRepository(isSaved = isSaved)
+                                            }
+                                            // Update the state with the updated list of repositories
+                                            _gitHubSearchResultState.value =
+                                                GitHubResponse.Success(updatedRepos)
+                                        }
+                                    }
+                            }
                         }
                 } catch (ex: Exception) {
                     _gitHubSearchResultState.value = GitHubResponse.Error(EXCEPTION)
-
                     logger.error(
                         TAG,
                         ex.message
@@ -100,21 +128,17 @@ class HomeViewModel @Inject constructor(
         searchKeyword = ""
     }
 
-    fun saveSelectedGitHubRepositoryInDatabase(gitHubRepository: GitHubRepository) {
+    /**
+     * Saves the selected GitHub repository in the local database
+     * to achieve a single source of truth (SSOT) for the selected GitHub repository using Room.
+     * This saved GitHub repository represents the most recently selected item to show in `GitHubRepositoryInfoScreen`.
+     *
+     * @param localGitHubRepository The GitHub repository to be saved in the database.
+     */
+    fun saveSelectedGitHubRepositoryInDatabase(localGitHubRepository: LocalGitHubRepository) {
         _isSelectedGitHubRepositorySavedState.value = GitHubResponse.Loading
         viewModelScope.launch {
             try {
-                val localGitHubRepository = LocalGitHubRepository(
-                    forksCount = gitHubRepository.forksCount,
-                    language = gitHubRepository.language,
-                    name = gitHubRepository.name,
-                    openIssuesCount = gitHubRepository.openIssuesCount,
-                    stargazersCount = gitHubRepository.stargazersCount,
-                    watchersCount = gitHubRepository.watchersCount,
-                    htmlUrl = gitHubRepository.htmlUrl,
-                    ownerLogin = gitHubRepository.owner?.login,
-                    ownerAvatarUrl = gitHubRepository.owner?.avatarUrl
-                )
                 localGitHubDatabaseRepository.saveSelectedGitHubRepositoryInDatabase(
                     localGitHubRepository
                 ).flowOn(Dispatchers.IO).collect {
@@ -125,7 +149,50 @@ class HomeViewModel @Inject constructor(
                 logger.error(
                     TAG,
                     ex.message
-                        ?: "An error occurred while saving selected GitHub repository: ${gitHubRepository.id}",
+                        ?: "An error occurred while saving selected GitHub repository: ${localGitHubRepository.id}",
+                    ex
+                )
+            }
+        }
+    }
+
+    /**
+     * Retrieves the recent updates from the database and updates the UI accordingly.
+     * Recent updates includes whether user has added a GitHub repository to user's saved list.
+     */
+    fun getRecentUpdateFromDatabase() {
+        viewModelScope.launch {
+            try {
+                if (_gitHubSearchResultState.value is GitHubResponse.Success) {
+                    // Extract the list of searched GitHub repositories from the current state
+                    val gitHubSearchResult =
+                        _gitHubSearchResultState.value as GitHubResponse.Success
+                    val searchedRepos = gitHubSearchResult.data
+                    if (searchedRepos.isNotEmpty()) {
+                        // Fetch the user's saved GitHub repositories from the local database
+                        localGitHubDatabaseRepository.getMySavedList()
+                            .flowOn(Dispatchers.IO)
+                            .collect { databaseResponse ->
+                                if (databaseResponse is GitHubResponse.Success) {
+                                    val savedRepos = databaseResponse.data
+                                    // Map each searched GitHub repository to update the isSaved property
+                                    val updatedRepos = searchedRepos.map { searchedRepo ->
+                                        val isSaved =
+                                            savedRepos.any { savedRepo -> savedRepo.id == searchedRepo.id }
+                                        searchedRepo.copy(isSaved = isSaved)
+                                    }
+                                    // Update the state with the updated list of GitHub repositories
+                                    _gitHubSearchResultState.value =
+                                        GitHubResponse.Success(updatedRepos)
+                                }
+                            }
+                    }
+                }
+            } catch (ex: Exception) {
+                _isSelectedGitHubRepositorySavedState.value = GitHubResponse.Error(EXCEPTION)
+                logger.error(
+                    TAG,
+                    ex.message ?: "An error occurred while updating GitHub repository list",
                     ex
                 )
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModel.kt
@@ -39,11 +39,7 @@ class HomeViewModel @Inject constructor(
     // StateFlow for holding the outcome of GitHub repository searches.
     // It emits [GitHubResponse] objects representing success, error, or loading state.
     private val _gitHubSearchResultState = MutableStateFlow<GitHubResponse<GitHubRepositoryList>>(
-        GitHubResponse.Success(
-            GitHubRepositoryList(
-                emptyList()
-            )
-        )
+        GitHubResponse.Success(GitHubRepositoryList(emptyList()))
     )
     val gitHubSearchResultState: StateFlow<GitHubResponse<GitHubRepositoryList>> =
         _gitHubSearchResultState

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModel.kt
@@ -123,9 +123,11 @@ class HomeViewModel @Inject constructor(
 
     /**
      * Clears the [searchKeyword] property by setting it to an empty string.
+     * Sets [gitHubSearchResultState] with a successful response of an empty list.
      */
     fun clearSearchKeyword() {
         searchKeyword = ""
+        _gitHubSearchResultState.value = GitHubResponse.Success(emptyList())
     }
 
     /**
@@ -158,7 +160,7 @@ class HomeViewModel @Inject constructor(
 
     /**
      * Retrieves the recent updates from the database and updates the UI accordingly.
-     * Recent updates includes whether user has added a GitHub repository to user's saved list.
+     * Recent updates includes whether user has added/removed a GitHub repository from user's saved list.
      */
     fun getRecentUpdateFromDatabase() {
         viewModelScope.launch {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/MySavedListViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/MySavedListViewModel.kt
@@ -1,0 +1,102 @@
+package jp.co.yumemi.android.code_check.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.android.code_check.constant.ResponseCode
+import jp.co.yumemi.android.code_check.logger.Logger
+import jp.co.yumemi.android.code_check.model.GitHubResponse
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
+import jp.co.yumemi.android.code_check.model.toLocalGitHubRepository
+import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * ViewModel class for managing the UI state and interactions related to the user's saved GitHub repositories list.
+ *
+ * @param localGitHubDatabaseRepository The repository for accessing local database operations related to GitHub repositories.
+ * @param logger The logger for logging errors.
+ */
+@HiltViewModel
+class MySavedListViewModel @Inject constructor(
+    private val localGitHubDatabaseRepository: LocalGitHubDatabaseRepository,
+    private val logger: Logger
+) : ViewModel() {
+    // Logging tag for this class
+    private val TAG = this.javaClass.simpleName
+
+    /*
+    StateFlow for holding the outcome of retrieving the user's saved list.
+    It emits [GitHubResponse] objects representing success, error, or loading state.
+     */
+    private val _mySavedListState =
+        MutableStateFlow<GitHubResponse<List<SavedGitHubRepository>>>(GitHubResponse.Success((emptyList())))
+    val mySavedListState: StateFlow<GitHubResponse<List<SavedGitHubRepository>>> = _mySavedListState
+
+    /*
+    StateFlow for holding the outcome of saving a selected GitHub repository in the database.
+    It emits [GitHubResponse] objects representing success, error, or loading state.
+     */
+    private val _isSelectedGitHubRepositorySavedState =
+        MutableStateFlow<GitHubResponse<Boolean>>(GitHubResponse.Loading)
+    val isSelectedGitHubRepositorySavedState: StateFlow<GitHubResponse<Boolean>> =
+        _isSelectedGitHubRepositorySavedState
+
+    /**
+     * Retrieves the user's saved GitHub repositories list from the local database.
+     * Updates the UI with the fetched list.
+     */
+    fun getMySavedList() {
+        _mySavedListState.value = GitHubResponse.Loading
+        viewModelScope.launch {
+            try {
+                localGitHubDatabaseRepository.getMySavedList()
+                    .flowOn(Dispatchers.IO)
+                    .collect {
+                        _mySavedListState.value = it
+                    }
+            } catch (ex: Exception) {
+                _mySavedListState.value = GitHubResponse.Error(ResponseCode.EXCEPTION)
+                logger.error(
+                    TAG,
+                    ex.message
+                        ?: "An error occurred while retrieving user's saved list",
+                    ex
+                )
+            }
+        }
+    }
+
+    /**
+     * Adds the selected GitHub repository to the user's saved list in the local database.
+     *
+     * @param savedGitHubRepository The repository to be added to user's saved list.
+     */
+    fun saveSelectedGitHubRepositoryInDatabase(savedGitHubRepository: SavedGitHubRepository) {
+        _isSelectedGitHubRepositorySavedState.value = GitHubResponse.Loading
+        viewModelScope.launch {
+            try {
+                val localGitHubRepository = savedGitHubRepository.toLocalGitHubRepository()
+                localGitHubDatabaseRepository.saveSelectedGitHubRepositoryInDatabase(
+                    localGitHubRepository
+                ).flowOn(Dispatchers.IO).collect {
+                    _isSelectedGitHubRepositorySavedState.value = it
+                }
+            } catch (ex: Exception) {
+                _isSelectedGitHubRepositorySavedState.value =
+                    GitHubResponse.Error(ResponseCode.EXCEPTION)
+                logger.error(
+                    TAG,
+                    ex.message
+                        ?: "An error occurred while saving selected GitHub repository: ${savedGitHubRepository.id}",
+                    ex
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/baseline_bookmark_24.xml
+++ b/app/src/main/res/drawable/baseline_bookmark_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17,3H7c-1.1,0 -1.99,0.9 -1.99,2L5,21l7,-3 7,3V5c0,-1.1 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_bookmark_add_24.xml
+++ b/app/src/main/res/drawable/baseline_bookmark_add_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,7h-2v2h-2V7h-2V5h2V3h2v2h2V7zM19,21l-7,-3l-7,3V5c0,-1.1 0.9,-2 2,-2l7,0c-0.63,0.84 -1,1.87 -1,3c0,2.76 2.24,5 5,5c0.34,0 0.68,-0.03 1,-0.1V21z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_bookmark_remove_24.xml
+++ b/app/src/main/res/drawable/baseline_bookmark_remove_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,7h-6V5h6V7zM19,10.9c-0.32,0.07 -0.66,0.1 -1,0.1c-2.76,0 -5,-2.24 -5,-5c0,-1.13 0.37,-2.16 1,-3L7,3C5.9,3 5,3.9 5,5v16l7,-3l7,3V10.9z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_collections_bookmark_24.xml
+++ b/app/src/main/res/drawable/baseline_collections_bookmark_24.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M4,6H2v14c0,1.1 0.9,2 2,2h14v-2H4V6z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,12l-2.5,-1.5L15,12L15,4h5v8z"/>
+    
+</vector>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Android Engineer CodeCheck</string>
+    <string name="app_name">Androidエンジニアコードチェック</string>
     <string name="searchInputText_hint">GitHub のリポジトリを検索できるよー</string>
     <string name="language_summary">" %s"</string>
     <string name="watchers_summary">" %s"</string>
@@ -16,7 +16,7 @@
     <string name="by">"オーナー "</string>
     <string name="null_value">"-"</string>
     <string name="retry">再試行</string>
-    <string name="no_result">結果がありません</string>
+    <string name="no_result">検索結果が見つかりませんでした</string>
     <string name="oh_no">エラー</string>
     <string name="no_internet">インターネット接続が見つかりませんでした。接続を確認して、再度お試しください。</string>
     <string name="invalid_request">エラーが発生しました。入力したリポジトリ名を確認して、再度お試しください。</string>
@@ -25,4 +25,13 @@
     <string name="timeout_error">エラーが発生しました。いつもより時間がかかっているようです。接続を確認して、再度お試しください。</string>
     <string name="loading">読み込み中</string>
     <string name="go_to_repository">リポジトリへ移動</string>
+    <string name="saved_screen_title">マイリスト</string>
+    <string name="saved_screen_description">保存したリポジトリのリストです</string>
+    <string name="home_screen_description">GitHubリポジトリを検索</string>
+    <string name="info_screen_title">情報</string>
+    <string name="info_screen_description">リポジトリの詳細情報</string>
+    <string name="unsave">保存解除</string>
+    <string name="save">保存</string>
+    <string name="saved">ブックマーク</string>
+    <string name="empty_saved_list">保存済みリストが空です</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="by">"by "</string>
     <string name="null_value">"-"</string>
     <string name="retry">Retry</string>
-    <string name="no_result">No Results</string>
+    <string name="no_result">Search results were not found</string>
     <string name="oh_no">Oh no!</string>
     <string name="no_internet">No Internet found. Please check your connection or try again.</string>
     <string name="invalid_request">Error occurred. Please check entered repository name and try again.</string>
@@ -24,4 +24,13 @@
     <string name="timeout_error">Error occurred. Looks like it is taking longer than usual. Please check your connection and try again.</string>
     <string name="loading">Loading</string>
     <string name="go_to_repository">Go to Repository</string>
+    <string name="saved_screen_title">My saved list</string>
+    <string name="saved_screen_description">See what I have saved</string>
+    <string name="home_screen_description">Search GitHub repositories</string>
+    <string name="info_screen_title">Information</string>
+    <string name="info_screen_description">See more about repository</string>
+    <string name="unsave">Remove from Saved</string>
+    <string name="save">Save</string>
+    <string name="saved">Saved</string>
+    <string name="empty_saved_list">Saved list is empty</string>
 </resources>

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModelTest.kt
@@ -1,15 +1,19 @@
 package jp.co.yumemi.android.code_check.viewModel
 
+import jp.co.yumemi.android.code_check.logger.Logger
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
 import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,16 +30,27 @@ import org.mockito.junit.MockitoJUnitRunner
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class GitHubRepositoryInfoViewModelTest {
+    /**
+     * TestDispatcher to run coroutines in tests.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @ObsoleteCoroutinesApi
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     private lateinit var viewModel: GitHubRepositoryInfoViewModel
 
     @Mock
     private lateinit var localGitHubDatabaseRepository: LocalGitHubDatabaseRepository
+
+    @Mock
+    private lateinit var logger: Logger
 
     /**
      * A mock instance of `LocalGitHubRepository` representing a test repository.
      * This object is used to provide expected data for the test cases.
      */
     private val testGitHubRepository = LocalGitHubRepository(
+        id = 123,
         forksCount = 50,
         language = "Kotlin",
         name = "My Awesome Project",
@@ -44,8 +59,19 @@ class GitHubRepositoryInfoViewModelTest {
         watchersCount = 75,
         htmlUrl = "https://github.com/user/my-awesome-project",
         ownerLogin = "user",
-        ownerAvatarUrl = "https://avatars.githubusercontent.com/user"
+        ownerAvatarUrl = "https://avatars.githubusercontent.com/user",
+        isSaved = true
     )
+
+    /**
+     * Setup method to initialize the objects before each test case.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        MockitoAnnotations.openMocks(this)
+    }
 
     /**
      * The ViewModel emits a success response containing the corresponding repository data
@@ -59,7 +85,8 @@ class GitHubRepositoryInfoViewModelTest {
             ).thenReturn(flowOf(GitHubResponse.Success(testGitHubRepository)))
 
             viewModel = GitHubRepositoryInfoViewModel(
-                localGitHubDatabaseRepository = localGitHubDatabaseRepository
+                localGitHubDatabaseRepository = localGitHubDatabaseRepository,
+                logger = logger
             )
 
             val gitHubRepositoryInfoFlow: Flow<GitHubResponse<LocalGitHubRepository?>> =
@@ -88,7 +115,8 @@ class GitHubRepositoryInfoViewModelTest {
             ).thenReturn(flowOf(GitHubResponse.Error(errorMessage)))
 
             viewModel = GitHubRepositoryInfoViewModel(
-                localGitHubDatabaseRepository = localGitHubDatabaseRepository
+                localGitHubDatabaseRepository = localGitHubDatabaseRepository,
+                logger = logger
             )
 
             val gitHubRepositoryInfoFlow: Flow<GitHubResponse<LocalGitHubRepository?>> =
@@ -115,7 +143,8 @@ class GitHubRepositoryInfoViewModelTest {
             ).thenReturn(flowOf(GitHubResponse.Success(null)))
 
             viewModel = GitHubRepositoryInfoViewModel(
-                localGitHubDatabaseRepository = localGitHubDatabaseRepository
+                localGitHubDatabaseRepository = localGitHubDatabaseRepository,
+                logger = logger
             )
 
             val gitHubRepositoryInfoFlow: Flow<GitHubResponse<LocalGitHubRepository?>> =


### PR DESCRIPTION
## Summary

This pull request introduces a new feature that allows users to add GitHub repositories to their saved list directly from the app information screen. Users often come across interesting repositories that they want to revisit later, and this feature provides a seamless way to accomplish that.

## Behavior

| Steps to follow  | Screenshots |
| ---- | ------------- |
|1. Enter some keywords.|<img src="https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/2d0cd660-c226-4756-84a5-87b322308462" width="150"/>|
|2. Search for repositories.|
|3. Select a specific result and you will be shown the details of the repository (repository name, owner icon, project language, number of stars, number of watchers, number of forks, number of issues) in detail screen.|<img src="https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/6a99b665-21f9-46fe-8851-b14b84e6c44d" width="150"/>|
|4. Tap on `Save` button in the bottom app bar to add repository to saved list.|
|5. Go to main screen and tap on `Saved` floating button to view saved list.| <img src="https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/028149f1-0cf6-49a7-a608-5887b9f13017" width="150"/> |
|6. In the detail screen, tap on `Remove from saved` button in the bottom app bar to remove repository from the saved list.|<img src="https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/8c37f2dc-eace-488e-be6c-4c43559b8e12" width="150"/>|

## Changes

- Implemented the logic to add/remove GitHub repositories to the user's saved list.
- Added UI components to enable users to save/remove repositories from the repository details screen.
- Implemented the logic to indicate user's saved repositories in the search results from API by showing a bookmark icon.
- Updated Room database to be able to save repositories in locally.
- Add comments for better readability and understandability.
- Updated Japanese translation.