### PR TITLE
Unit tests for ViewModels

### DIFF
--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/GitHubRepositoryInfoViewModelTest.kt
@@ -3,16 +3,19 @@ package jp.co.yumemi.android.code_check.viewModel
 import jp.co.yumemi.android.code_check.logger.Logger
 import jp.co.yumemi.android.code_check.model.GitHubResponse
 import jp.co.yumemi.android.code_check.model.LocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.toSavedGitHubRepository
 import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -71,6 +74,10 @@ class GitHubRepositoryInfoViewModelTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         MockitoAnnotations.openMocks(this)
+        viewModel = GitHubRepositoryInfoViewModel(
+            localGitHubDatabaseRepository = localGitHubDatabaseRepository,
+            logger = logger
+        )
     }
 
     /**
@@ -158,5 +165,221 @@ class GitHubRepositoryInfoViewModelTest {
                 assertTrue(gitHubRepositoryInfo is GitHubResponse.Success)
                 assertEquals(GitHubResponse.Success(null), gitHubRepositoryInfo)
             }
+        }
+
+    /**
+     * Test case to verify that addGitHubRepositoryToMySavedList executes onSuccess callback correctly on success.
+     */
+    @Test
+    fun `addGitHubRepositoryToMySavedList executes onSuccess callback correctly on success`() =
+        runTest {
+            val testSavedGitHubRepository =
+                testGitHubRepository.toSavedGitHubRepository(isSaved = true)
+            `when`(
+                localGitHubDatabaseRepository.addGitHubRepositoryToMySavedList(
+                    testSavedGitHubRepository
+                )
+            )
+                .thenReturn(MutableStateFlow(GitHubResponse.Success(true)))
+
+            // Initialize variables to track the callbacks
+            var onSuccessCalled = false
+            var onErrorCalled = false
+            var onLoadingCalled = false
+
+            viewModel.addGitHubRepositoryToMySavedList(
+                localGitHubRepository = testGitHubRepository,
+                onSuccess = { onSuccessCalled = true },
+                onError = { onErrorCalled = true },
+                onLoading = { onLoadingCalled = true }
+            )
+
+            // Ensure that onSuccess callback was invoked
+            assertTrue(onSuccessCalled)
+
+            // Ensure that onError and onLoading callbacks were not invoked
+            assertFalse(onErrorCalled)
+            assertFalse(onLoadingCalled)
+        }
+
+    /**
+     * Test case to verify that addGitHubRepositoryToMySavedList executes onError callback correctly on error.
+     */
+    @Test
+    fun `addGitHubRepositoryToMySavedList executes onError callback correctly on error`() =
+        runTest {
+            val testSavedGitHubRepository =
+                testGitHubRepository.toSavedGitHubRepository(isSaved = true)
+            val errorMessage = "Failed to addGitHubRepositoryToMySavedList"
+
+            `when`(
+                localGitHubDatabaseRepository.addGitHubRepositoryToMySavedList(
+                    testSavedGitHubRepository
+                )
+            )
+                .thenReturn(MutableStateFlow(GitHubResponse.Error(errorMessage)))
+
+            // Initialize variables to track the callbacks
+            var onSuccessCalled = false
+            var onErrorCalled = false
+            var onLoadingCalled = false
+
+            viewModel.addGitHubRepositoryToMySavedList(
+                localGitHubRepository = testGitHubRepository,
+                onSuccess = { onSuccessCalled = true },
+                onError = { onErrorCalled = true },
+                onLoading = { onLoadingCalled = true }
+            )
+
+            // Ensure that onError callback was invoked
+            assertTrue(onErrorCalled)
+
+            // Ensure that onSuccess and onLoading callbacks were not invoked
+            assertFalse(onSuccessCalled)
+            assertFalse(onLoadingCalled)
+        }
+
+    /**
+     * Test case to verify that addGitHubRepositoryToMySavedList executes onLoading callback correctly while waiting for response.
+     */
+    @Test
+    fun `addGitHubRepositoryToMySavedList executes onLoading callback correctly while waiting for response`() =
+        runTest {
+            val testSavedGitHubRepository =
+                testGitHubRepository.toSavedGitHubRepository(isSaved = true)
+
+            `when`(
+                localGitHubDatabaseRepository.addGitHubRepositoryToMySavedList(
+                    testSavedGitHubRepository
+                )
+            )
+                .thenReturn(MutableStateFlow(GitHubResponse.Loading))
+
+            // Initialize variables to track the callbacks
+            var onSuccessCalled = false
+            var onErrorCalled = false
+            var onLoadingCalled = false
+
+            viewModel.addGitHubRepositoryToMySavedList(
+                localGitHubRepository = testGitHubRepository,
+                onSuccess = { onSuccessCalled = true },
+                onError = { onErrorCalled = true },
+                onLoading = { onLoadingCalled = true }
+            )
+
+            // Ensure that onLoading callback was invoked
+            assertTrue(onLoadingCalled)
+
+            // Ensure that onSuccess and onError callbacks were not invoked
+            assertFalse(onSuccessCalled)
+            assertFalse(onErrorCalled)
+        }
+
+    /**
+     * Test case to verify that removeGitHubRepositoryFromMySavedList executes onSuccess callback correctly on success.
+     */
+    @Test
+    fun `removeGitHubRepositoryFromMySavedList executes onSuccess callback correctly on success`() =
+        runTest {
+            val testSavedGitHubRepository =
+                testGitHubRepository.toSavedGitHubRepository(isSaved = false)
+            `when`(
+                localGitHubDatabaseRepository.removeGitHubRepositoryFromMySavedList(
+                    testSavedGitHubRepository
+                )
+            )
+                .thenReturn(MutableStateFlow(GitHubResponse.Success(true)))
+
+            // Initialize variables to track the callbacks
+            var onSuccessCalled = false
+            var onErrorCalled = false
+            var onLoadingCalled = false
+
+            viewModel.removeGitHubRepositoryFromMySavedList(
+                localGitHubRepository = testGitHubRepository,
+                onSuccess = { onSuccessCalled = true },
+                onError = { onErrorCalled = true },
+                onLoading = { onLoadingCalled = true }
+            )
+
+            // Ensure that onSuccess callback was invoked
+            assertTrue(onSuccessCalled)
+
+            // Ensure that onError and onLoading callbacks were not invoked
+            assertFalse(onErrorCalled)
+            assertFalse(onLoadingCalled)
+        }
+
+    /**
+     * Test case to verify that removeGitHubRepositoryFromMySavedList executes onError callback correctly on error.
+     */
+    @Test
+    fun `removeGitHubRepositoryFromMySavedList executes onError callback correctly on error`() =
+        runTest {
+            val testSavedGitHubRepository =
+                testGitHubRepository.toSavedGitHubRepository(isSaved = false)
+            val errorMessage = "Failed to addGitHubRepositoryToMySavedList"
+
+            `when`(
+                localGitHubDatabaseRepository.removeGitHubRepositoryFromMySavedList(
+                    testSavedGitHubRepository
+                )
+            )
+                .thenReturn(MutableStateFlow(GitHubResponse.Error(errorMessage)))
+
+            // Initialize variables to track the callbacks
+            var onSuccessCalled = false
+            var onErrorCalled = false
+            var onLoadingCalled = false
+
+            viewModel.removeGitHubRepositoryFromMySavedList(
+                localGitHubRepository = testGitHubRepository,
+                onSuccess = { onSuccessCalled = true },
+                onError = { onErrorCalled = true },
+                onLoading = { onLoadingCalled = true }
+            )
+
+            // Ensure that onError callback was invoked
+            assertTrue(onErrorCalled)
+
+            // Ensure that onSuccess and onLoading callbacks were not invoked
+            assertFalse(onSuccessCalled)
+            assertFalse(onLoadingCalled)
+        }
+
+    /**
+     * Test case to verify that removeGitHubRepositoryFromMySavedList executes onLoading callback correctly while waiting for response.
+     */
+    @Test
+    fun `removeGitHubRepositoryFromMySavedList executes onLoading callback correctly while waiting for response`() =
+        runTest {
+            val testSavedGitHubRepository =
+                testGitHubRepository.toSavedGitHubRepository(isSaved = false)
+
+            `when`(
+                localGitHubDatabaseRepository.removeGitHubRepositoryFromMySavedList(
+                    testSavedGitHubRepository
+                )
+            )
+                .thenReturn(MutableStateFlow(GitHubResponse.Loading))
+
+            // Initialize variables to track the callbacks
+            var onSuccessCalled = false
+            var onErrorCalled = false
+            var onLoadingCalled = false
+
+            viewModel.removeGitHubRepositoryFromMySavedList(
+                localGitHubRepository = testGitHubRepository,
+                onSuccess = { onSuccessCalled = true },
+                onError = { onErrorCalled = true },
+                onLoading = { onLoadingCalled = true }
+            )
+
+            // Ensure that onLoading callback was invoked
+            assertTrue(onLoadingCalled)
+
+            // Ensure that onSuccess and onError callbacks were not invoked
+            assertFalse(onSuccessCalled)
+            assertFalse(onErrorCalled)
         }
 }

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModelTest.kt
@@ -1,0 +1,299 @@
+package jp.co.yumemi.android.code_check.viewModel
+
+import jp.co.yumemi.android.code_check.logger.Logger
+import jp.co.yumemi.android.code_check.model.GitHubRepository
+import jp.co.yumemi.android.code_check.model.GitHubRepositoryList
+import jp.co.yumemi.android.code_check.model.GitHubRepositoryOwner
+import jp.co.yumemi.android.code_check.model.GitHubResponse
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
+import jp.co.yumemi.android.code_check.model.toLocalGitHubRepository
+import jp.co.yumemi.android.code_check.model.toSavedGitHubRepository
+import jp.co.yumemi.android.code_check.repository.GitHubApiRepository
+import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Unit test class for `HomeViewModel`. This class verifies the
+ * behavior of the ViewModel under various scenarios.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class HomeViewModelTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @ObsoleteCoroutinesApi
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var viewModel: HomeViewModel
+
+    @Mock
+    private lateinit var gitHubApiRepository: GitHubApiRepository
+
+    @Mock
+    private lateinit var localGitHubDatabaseRepository: LocalGitHubDatabaseRepository
+
+    @Mock
+    private lateinit var logger: Logger
+
+    /**
+     * A mock instance of `GitHubRepository` representing test repositories.
+     */
+    private val testGitHubRepository1 = GitHubRepository(
+        id = 1,
+        name = "result repo 1/repo 1",
+        forksCount = 10,
+        language = "",
+        owner = GitHubRepositoryOwner(login = "name", avatarUrl = "url"),
+        stargazersCount = 10,
+        watchersCount = 10,
+        openIssuesCount = 10,
+        htmlUrl = "html url"
+    )
+    private val testGitHubRepository2 = GitHubRepository(
+        id = 2,
+        name = "result repo 2/repo 2",
+        forksCount = 20,
+        language = "",
+        owner = GitHubRepositoryOwner(login = "name", avatarUrl = "url"),
+        stargazersCount = 20,
+        watchersCount = 20,
+        openIssuesCount = 20,
+        htmlUrl = "html url"
+    )
+
+    /**
+     * Setup method to initialize the objects before each test case.
+     */
+    @OptIn(ObsoleteCoroutinesApi::class)
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        MockitoAnnotations.openMocks(this)
+        viewModel = HomeViewModel(
+            gitHubApiRepository = gitHubApiRepository,
+            localGitHubDatabaseRepository = localGitHubDatabaseRepository,
+            logger = logger
+        )
+    }
+
+    @Test
+    fun `initially search keyword should be empty`() {
+        assertTrue(viewModel.searchKeyword.isEmpty())
+    }
+
+    @Test
+    fun `provided valid keyword should search for the repository list`() =
+        runTest {
+            // List represents GitHub repositories saved in user's saved list
+            val savedRepoList = emptyList<SavedGitHubRepository>()
+
+            // List represents GitHub repositories searched from GitHub API
+            val searchedRepoList = listOf(testGitHubRepository1, testGitHubRepository2)
+
+            // List represents expected GitHub repositories result
+            val expectedRepoList = listOf(
+                testGitHubRepository1.toLocalGitHubRepository(isSaved = false),
+                testGitHubRepository2.toLocalGitHubRepository(isSaved = false)
+            )
+
+            // Search keyword
+            val keyword = "repo"
+
+            `when`(localGitHubDatabaseRepository.getMySavedList())
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(savedRepoList))
+                )
+            `when`(gitHubApiRepository.searchGitHubRepositories(keyword))
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(GitHubRepositoryList(searchedRepoList)))
+                )
+
+            viewModel.updateSearchKeyword(keyword = keyword)
+            viewModel.searchGitHubRepositories()
+            // Verify that gitHubSearchResultState is updated correctly
+            assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Success)
+            assertTrue((viewModel.gitHubSearchResultState.value as GitHubResponse.Success).data == expectedRepoList)
+        }
+
+    @Test
+    fun `provided invalid keyword should empty the repository list`() = runTest {
+        viewModel.updateSearchKeyword(keyword = "    ")
+        viewModel.searchGitHubRepositories()
+        assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Success)
+        assertTrue((viewModel.gitHubSearchResultState.value as GitHubResponse.Success).data == emptyList<LocalGitHubDatabaseRepository>())
+    }
+
+    @Test
+    fun `provided empty keyword should empty the repository list`() = runTest {
+        viewModel.updateSearchKeyword(keyword = "")
+        viewModel.searchGitHubRepositories()
+        assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Success)
+        assertTrue((viewModel.gitHubSearchResultState.value as GitHubResponse.Success).data == emptyList<LocalGitHubDatabaseRepository>())
+    }
+
+    @Test
+    fun `clearSearchKeyword should clear the keyword and empty the repository list`() = runTest {
+        viewModel.clearSearchKeyword()
+        assertTrue(viewModel.searchKeyword.isEmpty())
+        assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Success)
+        assertTrue((viewModel.gitHubSearchResultState.value as GitHubResponse.Success).data == emptyList<LocalGitHubDatabaseRepository>())
+    }
+
+    /**
+     * The ViewModel emits a success response containing the corresponding repository data
+     * retrieved from the `gitHubApiRepository`.
+     */
+    @Test
+    fun `searchGitHubRepositories should emit success response if no error`() =
+        runTest {
+            // List represents GitHub repositories saved in user's saved list
+            val savedRepoList = emptyList<SavedGitHubRepository>()
+
+            // List represents GitHub repositories searched from GitHub API
+            val searchedRepoList = listOf(testGitHubRepository1, testGitHubRepository2)
+
+            // Search keyword
+            val keyword = "repo"
+
+            `when`(localGitHubDatabaseRepository.getMySavedList())
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(savedRepoList))
+                )
+            `when`(gitHubApiRepository.searchGitHubRepositories(keyword))
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(GitHubRepositoryList(searchedRepoList)))
+                )
+
+            viewModel.updateSearchKeyword(keyword = keyword)
+            viewModel.searchGitHubRepositories()
+
+            // Verify that gitHubSearchResultState is updated correctly
+            assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Success)
+        }
+
+    /**
+     * The ViewModel emits a error response containing the corresponding error message
+     * retrieved from the `gitHubApiRepository`.
+     */
+    @Test
+    fun `searchGitHubRepositories should emit error response if on error`() =
+        runTest {
+            val keyword = "repo"
+            val errorMessage = "Failed searchGitHubRepositories"
+
+            `when`(localGitHubDatabaseRepository.getMySavedList())
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(emptyList()))
+                )
+            `when`(gitHubApiRepository.searchGitHubRepositories(keyword))
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Error(errorMessage))
+                )
+
+            viewModel.updateSearchKeyword(keyword = keyword)
+            viewModel.searchGitHubRepositories()
+
+            // Verify that gitHubSearchResultState is updated correctly
+            assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Error)
+            assertTrue((viewModel.gitHubSearchResultState.value as GitHubResponse.Error).error == errorMessage)
+        }
+
+    /**
+     * The ViewModel emits a success response containing the corresponding repository data
+     * retrieved from the `gitHubApiRepository`.
+     */
+    @Test
+    fun `successful searchGitHubRepositories should indicate whether searched repositories saved in user's saved list`() =
+        runTest {
+            // List represents GitHub repositories saved in user's saved list
+            val savedRepoList = listOf(
+                testGitHubRepository1.toLocalGitHubRepository(isSaved = true)
+                    .toSavedGitHubRepository(isSaved = true)
+            )
+
+            // List represents GitHub repositories searched from GitHub API
+            val searchedRepoList = listOf(testGitHubRepository1, testGitHubRepository2)
+
+            // List represents expected GitHub repositories result
+            val expectedRepoList = listOf(
+                testGitHubRepository1.toLocalGitHubRepository(isSaved = true),
+                testGitHubRepository2.toLocalGitHubRepository(isSaved = false)
+            )
+
+            // Search keyword
+            val keyword = "repo"
+
+            `when`(localGitHubDatabaseRepository.getMySavedList())
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(savedRepoList))
+                )
+            `when`(gitHubApiRepository.searchGitHubRepositories(keyword))
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(GitHubRepositoryList(searchedRepoList)))
+                )
+
+            viewModel.updateSearchKeyword(keyword = keyword)
+            viewModel.searchGitHubRepositories()
+
+            // Verify that gitHubSearchResultState is updated correctly
+            assertTrue(viewModel.gitHubSearchResultState.value is GitHubResponse.Success)
+            // Verify that GitHub repository is indicated as saved
+            assertTrue((viewModel.gitHubSearchResultState.value as GitHubResponse.Success).data == expectedRepoList)
+        }
+
+    /**
+     * The ViewModel emits a success response containing the corresponding success message
+     * retrieved from the `localGitHubDatabaseRepository`.
+     */
+    @Test
+    fun `saveSelectedGitHubRepositoryInDatabase should emit success response if no error`() =
+        runTest {
+            val testLocalRepo = testGitHubRepository2.toLocalGitHubRepository(isSaved = false)
+
+            `when`(localGitHubDatabaseRepository.saveSelectedGitHubRepositoryInDatabase(testLocalRepo))
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(true))
+                )
+
+            viewModel.saveSelectedGitHubRepositoryInDatabase(testLocalRepo)
+
+            // Verify that gitHubSearchResultState is updated correctly
+            assertTrue(viewModel.isSelectedGitHubRepositorySavedState.value is GitHubResponse.Success)
+            assertTrue((viewModel.isSelectedGitHubRepositorySavedState.value as GitHubResponse.Success).data)
+        }
+
+    /**
+     * The ViewModel emits a error response containing the corresponding error message
+     * retrieved from the `localGitHubDatabaseRepository`.
+     */
+    @Test
+    fun `saveSelectedGitHubRepositoryInDatabase should emit error response if on error`() =
+        runTest {
+            val testLocalRepo = testGitHubRepository2.toLocalGitHubRepository(isSaved = false)
+            val errorMessage = "Failed searchGitHubRepositories"
+
+            `when`(localGitHubDatabaseRepository.saveSelectedGitHubRepositoryInDatabase(testLocalRepo))
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Error(errorMessage))
+                )
+
+            viewModel.saveSelectedGitHubRepositoryInDatabase(testLocalRepo)
+
+            // Verify that gitHubSearchResultState is updated correctly
+            assertTrue(viewModel.isSelectedGitHubRepositorySavedState.value is GitHubResponse.Error)
+            assertTrue((viewModel.isSelectedGitHubRepositorySavedState.value as GitHubResponse.Error).error == errorMessage)
+        }
+}

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModelTest.kt
@@ -97,9 +97,6 @@ class HomeViewModelTest {
     @Test
     fun `provided valid keyword should search for the repository list`() =
         runTest {
-            // List represents GitHub repositories saved in user's saved list
-            val savedRepoList = emptyList<SavedGitHubRepository>()
-
             // List represents GitHub repositories searched from GitHub API
             val searchedRepoList = listOf(testGitHubRepository1, testGitHubRepository2)
 
@@ -114,7 +111,7 @@ class HomeViewModelTest {
 
             `when`(localGitHubDatabaseRepository.getMySavedList())
                 .thenReturn(
-                    MutableStateFlow(GitHubResponse.Success(savedRepoList))
+                    MutableStateFlow(GitHubResponse.Success(emptyList()))
                 )
             `when`(gitHubApiRepository.searchGitHubRepositories(keyword))
                 .thenReturn(

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/HomeViewModelTest.kt
@@ -191,10 +191,6 @@ class HomeViewModelTest {
             val keyword = "repo"
             val errorMessage = "Failed searchGitHubRepositories"
 
-            `when`(localGitHubDatabaseRepository.getMySavedList())
-                .thenReturn(
-                    MutableStateFlow(GitHubResponse.Success(emptyList()))
-                )
             `when`(gitHubApiRepository.searchGitHubRepositories(keyword))
                 .thenReturn(
                     MutableStateFlow(GitHubResponse.Error(errorMessage))

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/MySavedListViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/viewModel/MySavedListViewModelTest.kt
@@ -1,0 +1,173 @@
+package jp.co.yumemi.android.code_check.viewModel
+
+import jp.co.yumemi.android.code_check.logger.Logger
+import jp.co.yumemi.android.code_check.model.GitHubResponse
+import jp.co.yumemi.android.code_check.model.SavedGitHubRepository
+import jp.co.yumemi.android.code_check.model.toLocalGitHubRepository
+import jp.co.yumemi.android.code_check.repository.LocalGitHubDatabaseRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Unit test class for `MySavedListViewModel`. This class verifies the
+ * behavior of the ViewModel under various scenarios.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class MySavedListViewModelTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @ObsoleteCoroutinesApi
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var viewModel: MySavedListViewModel
+
+    @Mock
+    private lateinit var localGitHubDatabaseRepository: LocalGitHubDatabaseRepository
+
+    @Mock
+    private lateinit var logger: Logger
+
+    /**
+     * A mock instance of `SavedGitHubRepository` representing a test repository.
+     * This object is used to provide expected data for the test cases.
+     */
+    private val testGitHubRepository = SavedGitHubRepository(
+        id = 123,
+        forksCount = 50,
+        language = "Kotlin",
+        name = "My Awesome Project",
+        openIssuesCount = 2,
+        stargazersCount = 100,
+        watchersCount = 75,
+        htmlUrl = "https://github.com/user/my-awesome-project",
+        ownerLogin = "user",
+        ownerAvatarUrl = "https://avatars.githubusercontent.com/user",
+        isSaved = true
+    )
+
+
+    /**
+     * Setup method to initialize the objects before each test case.
+     */
+    @OptIn(ObsoleteCoroutinesApi::class)
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        MockitoAnnotations.openMocks(this)
+        viewModel = MySavedListViewModel(
+            localGitHubDatabaseRepository = localGitHubDatabaseRepository,
+            logger = logger
+        )
+    }
+
+    /**
+     * The ViewModel emits a success response containing the corresponding saved repository data
+     * retrieved from the `localGitHubDatabaseRepository`.
+     */
+    @Test
+    fun `getMySavedList should emit success response if no error`() =
+        runTest {
+            // List represents GitHub repositories saved in user's list
+            val savedRepoList = listOf(testGitHubRepository)
+
+            `when`(localGitHubDatabaseRepository.getMySavedList())
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(savedRepoList))
+                )
+
+            viewModel.getMySavedList()
+
+            // Verify that mySavedListState is updated correctly
+            assertTrue(viewModel.mySavedListState.value is GitHubResponse.Success)
+            assertTrue((viewModel.mySavedListState.value as GitHubResponse.Success).data == savedRepoList)
+
+        }
+
+    /**
+     * The ViewModel emits a error response containing the corresponding error
+     * retrieved from the `localGitHubDatabaseRepository`.
+     */
+    @Test
+    fun `getMySavedList should emit error response if on error`() =
+        runTest {
+            val errorMessage = "Failed searchGitHubRepositories"
+
+            `when`(localGitHubDatabaseRepository.getMySavedList())
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Error(errorMessage))
+                )
+
+            viewModel.getMySavedList()
+
+            // Verify that mySavedListState is updated correctly
+            assertTrue(viewModel.mySavedListState.value is GitHubResponse.Error)
+            assertTrue((viewModel.mySavedListState.value as GitHubResponse.Error).error == errorMessage)
+
+        }
+
+    /**
+     * The ViewModel emits a success response containing the corresponding success message
+     * retrieved from the `localGitHubDatabaseRepository`.
+     */
+    @Test
+    fun `saveSelectedGitHubRepositoryInDatabase should emit success response if no error`() =
+        runTest {
+            val testLocalRepo = testGitHubRepository.toLocalGitHubRepository()
+
+            Mockito.`when`(
+                localGitHubDatabaseRepository.saveSelectedGitHubRepositoryInDatabase(
+                    testLocalRepo
+                )
+            )
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Success(true))
+                )
+
+            viewModel.saveSelectedGitHubRepositoryInDatabase(testGitHubRepository)
+
+            // Verify that isSelectedGitHubRepositorySavedState is updated correctly
+            Assert.assertTrue(viewModel.isSelectedGitHubRepositorySavedState.value is GitHubResponse.Success)
+            Assert.assertTrue((viewModel.isSelectedGitHubRepositorySavedState.value as GitHubResponse.Success).data)
+        }
+
+    /**
+     * The ViewModel emits a error response containing the corresponding error message
+     * retrieved from the `localGitHubDatabaseRepository`.
+     */
+    @Test
+    fun `saveSelectedGitHubRepositoryInDatabase should emit error response if on error`() =
+        runTest {
+            var testLocalRepo = testGitHubRepository.toLocalGitHubRepository()
+            val errorMessage = "Failed searchGitHubRepositories"
+
+            `when`(
+                localGitHubDatabaseRepository.saveSelectedGitHubRepositoryInDatabase(
+                    testLocalRepo
+                )
+            )
+                .thenReturn(
+                    MutableStateFlow(GitHubResponse.Error(errorMessage))
+                )
+
+            viewModel.saveSelectedGitHubRepositoryInDatabase(testGitHubRepository)
+
+            // Verify that isSelectedGitHubRepositorySavedState is updated correctly
+            assertTrue(viewModel.isSelectedGitHubRepositorySavedState.value is GitHubResponse.Error)
+            assertTrue((viewModel.isSelectedGitHubRepositorySavedState.value as GitHubResponse.Error).error == errorMessage)
+        }
+}


### PR DESCRIPTION
## Summary

This pull request introduces unit tests for ViewModel classes to verify the behavior under various scenarios.

## Changes

1.  HomeViewModel unit tests- This ViewModel is responsible for managing user interactions and business logic related to GitHub repository search functionality within the application. 

- Search functionality
-- Verified the ViewModel's behavior when initiating searches and handling search results.
--Tested scenarios with valid, invalid, and empty search keywords to ensure proper functionality.

- Repository management
--Validated the ViewModel's response when saving selected GitHub repositories to the local database.
--Ensured correct handling of success and error responses during repository save operations.

![image](https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/48b3437d-10b3-4dfa-8544-e2466bdd0954)

2. GitHubRepositoryInfoViewModel unit tests- This ViewModel is responsible for managing the state and business logic related to GitHub repository information within the application. 

- getSelectedGitHubRepositoryFromDatabase
--Verifies the ViewModel's behavior when retrieving GitHub repository data from the local database.
--Tests success, error, and null response scenarios.

- addGitHubRepositoryToMySavedList
--Validates the ViewModel's response when adding a repository to the user's saved list.
--Tests success, error, and loading state callbacks.

- removeGitHubRepositoryFromMySavedList
--Ensures the ViewModel behaves correctly when removing a repository from the user's saved list.
--Verifies success, error, and loading state callbacks.

![image](https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/145bda2d-0b46-4af4-834c-a68a2c5ae75c)

3. MySavedListViewModel unit tests- This ViewModel is responsible for managing user-saved GitHub repositories within the application. 

- Retrieve saved list
--Verified the ViewModel's response when retrieving the list of saved GitHub repositories from the local database.
--Tested scenarios with both successful retrieval and error responses to ensure proper error handling.

- Save repository
--Validated the ViewModel's behavior when saving a selected GitHub repository to the local database.
--Ensured correct handling of success and error responses during repository save operations.

![image](https://github.com/udeni-gtp01/android-engineer-codecheck/assets/115888754/a2f93933-831e-4f87-859e-d5253144fb16)
